### PR TITLE
修复：避免大首帧数据导致短剧视频重试栈溢出

### DIFF
--- a/web/src/lib/server/reference-asset-store.test.ts
+++ b/web/src/lib/server/reference-asset-store.test.ts
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
     cleanupExpired: vi.fn(),
     getRegistration: vi.fn(),
+    register: vi.fn(),
     stat: vi.fn(),
     unlink: vi.fn(),
+    writeFile: vi.fn(),
 }));
 
 vi.mock("node:fs/promises", () => ({
@@ -12,12 +14,13 @@ vi.mock("node:fs/promises", () => ({
     mkdir: vi.fn(),
     stat: mocks.stat,
     unlink: mocks.unlink,
-    writeFile: vi.fn(),
+    writeFile: mocks.writeFile,
 }));
 vi.mock("@/lib/server/local-media-registry", () => ({
     getLocalMediaRegistration: mocks.getRegistration,
-    registerLocalMediaAsset: vi.fn(),
+    registerLocalMediaAsset: mocks.register,
 }));
+vi.mock("@/lib/server/object-storage-service", () => ({ persistExternalMediaIfEnabled: vi.fn(async () => null) }));
 vi.mock("@/lib/server/local-media-storage", () => ({
     cleanupExpiredLocalMediaAssets: mocks.cleanupExpired,
     createDatedMediaPath: vi.fn(() => "temporary/2026/01/01/images/file.png"),
@@ -34,6 +37,16 @@ describe("reference asset lifecycle boundaries", () => {
     it("does not run media cleanup from the online write path", async () => {
         await expect(writeReferenceMediaDataUrl("invalid", "image", { ownerUserId: "user-one", source: "test" })).rejects.toThrow("参考素材格式不正确");
         expect(mocks.cleanupExpired).not.toHaveBeenCalled();
+    });
+
+    it("accepts a generated frame whose base64 exceeds the V8 regexp stack boundary", async () => {
+        const bytes = Buffer.alloc(3_300_000, 1);
+
+        await expect(writeReferenceMediaDataUrl(`data:image/png;base64,${bytes.toString("base64")}`, "image", { ownerUserId: "user-one", source: "test" })).resolves.toMatchObject({ bytes: bytes.length, mimeType: "image/png" });
+        const written = mocks.writeFile.mock.calls[0]?.[1] as Buffer;
+        expect(Buffer.isBuffer(written)).toBe(true);
+        expect(written.length).toBe(bytes.length);
+        expect(written[0]).toBe(1);
     });
 
     it("leaves expired temporary files for reference-aware maintenance", async () => {

--- a/web/src/lib/server/reference-asset-store.ts
+++ b/web/src/lib/server/reference-asset-store.ts
@@ -120,11 +120,14 @@ function referenceRegistration(token: string, persistent: boolean, type: "image"
 }
 
 function parseMediaDataUrl(dataUrl: string) {
-    const match = dataUrl.match(/^data:((?:image\/(?:png|jpe?g|webp|gif))|(?:video\/(?:mp4|webm|quicktime))|(?:audio\/(?:mpeg|mp3|wav|x-wav|ogg|opus|aac|flac)));base64,([a-z0-9+/=\s]+)$/i);
-    if (!match) return null;
-    const mimeType = normalizeMimeType(match[1]);
-    const bytes = Buffer.from(match[2].replace(/\s/g, ""), "base64");
-    return bytes.length ? { mimeType, bytes } : null;
+    const separator = dataUrl.indexOf(",");
+    if (separator < 0) return null;
+    const header = dataUrl.slice(0, separator).match(/^data:((?:image\/(?:png|jpe?g|webp|gif))|(?:video\/(?:mp4|webm|quicktime))|(?:audio\/(?:mpeg|mp3|wav|x-wav|ogg|opus|aac|flac)));base64$/i);
+    const encoded = dataUrl.slice(separator + 1);
+    if (!header || !encoded || encoded.length % 4 !== 0) return null;
+    const mimeType = normalizeMimeType(header[1]);
+    const bytes = Buffer.from(encoded, "base64");
+    return bytes.length && bytes.toString("base64") === encoded ? { mimeType, bytes } : null;
 }
 
 function normalizeMimeType(value: string) {


### PR DESCRIPTION
## 变更目的

短剧失败镜头单独点击“重试镜头”时，如果首帧以较大的 Data URL 进入参考素材持久化流程，服务端可能返回 `Maximum call stack size exceeded`。

问题来自 `parseMediaDataUrl` 使用一个正则同时匹配 Data URL 头部和完整 Base64 正文。约 3.3 MB 的 PNG 转为约 440 万字符的 Base64 后，会触发 V8 在大正则输入上的调用栈溢出，导致 `/api/reference-assets` 无法完成，视频重试任务也无法进入上游执行。

## 主要变更

- 先按第一个逗号拆分 Data URL 的 header 与正文。
- 正则只校验短小的媒体类型和 `;base64` header，不再扫描超长 Base64 正文。
- 使用 `Buffer.from(encoded, base64)` 解码正文，并通过 Base64 往返结果进行严格合法性校验。
- 新增 3,300,000 字节图片 Data URL 回归测试，验证大首帧可以成功解析并写入持久化流程。
- 仅修改 `reference-asset-store.ts` 与对应测试文件，不涉及接口、数据库或计费契约。

## 验证

- [x] `pnpm exec vitest run src/lib/server/reference-asset-store.test.ts`：3/3 通过。
- [x] `pnpm typecheck`：通过。
- [x] 相关 ESLint 与全量 `pnpm lint`：通过。
- [x] 两个改动文件的 Prettier 检查：通过。
- [x] `pnpm build`：通过。
- [x] `git diff --check`：通过。
- [x] 没有提交密钥、数据库、日志、构建产物或与项目无关的文件。
- [ ] 全量 `pnpm test` 未全部通过：2232 passed、9 skipped、28 failed。28 项失败全部集中在 `src/lib/server/active-protocol-media-matrix.live.test.ts`，表现为 TCP fixture timeout / media fetch；单独重跑该文件仍为 28 failed、12 passed，属于当前环境或 live fixture 缺口，与本次两文件修复无直接关联。

## 风险与回滚

风险较低。解析器现在只接受规范、可往返的 Base64 正文；项目内部生成的 Data URL 使用规范 Base64。回滚本提交即可恢复旧解析逻辑，不涉及数据迁移。

仍需在真实生产短剧失败镜头上验证：`/api/reference-assets` 成功、视频任务进入后台生成运维与 Vidu 执行链路。

I have read and agree to CLA.md.