### PR TITLE
fix(image-tasks): detect raw JPEG base64 before URL parsing

### DIFF
--- a/web/src/app/api/image-tasks/image-task-support.test.ts
+++ b/web/src/app/api/image-tasks/image-task-support.test.ts
@@ -7,6 +7,7 @@ import { maintenanceWorkerContext } from "@/lib/server/maintenance-auth";
 import {
     allowsImageProtocolFallback,
     ImageQueryContractError,
+    findImageResult,
     imageRequestAspectRatio,
     imageTaskPollAttempts,
     imageTaskPollUrls,
@@ -97,6 +98,13 @@ describe("GlobalAiOpc image task paths", () => {
         expect(imageRequestAspectRatio("1824x1024")).toBe("16:9");
         expect(imageRequestAspectRatio("1024x1536")).toBe("2:3");
         expect(imageRequestAspectRatio("9:16")).toBe("9:16");
+    });
+
+    it("treats raw JPEG base64 as inline image data before relative URL parsing", () => {
+        const jpegBase64 = `/9j/${"A".repeat(96)}`;
+        expect(findImageResult(jpegBase64, "https://provider.example/v1/images/generations", config)).toMatchObject({
+            dataUrl: `data:image/jpeg;base64,${jpegBase64}`,
+        });
     });
 
     it("uses the configured create and result endpoints instead of OpenAI defaults", async () => {

--- a/web/src/app/api/image-tasks/image-task-support.ts
+++ b/web/src/app/api/image-tasks/image-task-support.ts
@@ -391,6 +391,11 @@ export function findImageResults(value: unknown, baseUrl: string, config: ImageT
 function collectImageResults(value: unknown, baseUrl: string, config: ImageTaskConfig, depth: number, images: ImageTaskMediaResult[]) {
     if (!value || depth > 6) return null;
     if (typeof value === "string") {
+        const inlineImage = rawImageBase64DataUrl(value);
+        if (inlineImage) {
+            images.push({ dataUrl: inlineImage });
+            return;
+        }
         const url = resolveImageUrlLike(value, baseUrl, config, false);
         if (url) images.push(url);
         const dataUrl = resolveImageBase64Like(value);
@@ -430,10 +435,26 @@ export function resolveImageUrlLike(value: string, baseUrl: string, config: Imag
     return null;
 }
 
+function rawImageBase64DataUrl(value: string) {
+    const base64 = value.trim().replace(/\s/g, "");
+    const mimeType = base64.startsWith("/9j/")
+        ? "image/jpeg"
+        : base64.startsWith("iVBORw0KGgo")
+          ? "image/png"
+          : base64.startsWith("R0lGOD")
+            ? "image/gif"
+            : base64.startsWith("UklGR")
+              ? "image/webp"
+              : "";
+    return mimeType && /^[a-z0-9+/=_-]+$/i.test(base64) ? `data:${mimeType};base64,${base64}` : "";
+}
+
 export function resolveImageBase64Like(value: string) {
     const base64 = value.trim();
     if (!base64) return "";
     if (/^data:image\//i.test(base64)) return base64;
+    const rawImage = rawImageBase64DataUrl(base64);
+    if (rawImage) return rawImage;
     if (base64.length < 64 || !/^[a-z0-9+/=_-]+$/i.test(base64.replace(/\s/g, ""))) return "";
     return `data:image/png;base64,${base64.replace(/\s/g, "")}`;
 }


### PR DESCRIPTION
## Summary

Fix image generation responses containing raw JPEG Base64 data being misclassified as relative URLs.

## Root cause

JPEG Base64 commonly starts with `/9j/`. The image result parser attempted URL resolution before Base64 detection, so `/9j/...` values were interpreted as relative paths and later failed during image persistence.

## Changes

- Detect common raw image Base64 signatures before URL parsing.
- Preserve MIME types for JPEG, PNG, GIF, and WebP data URLs.
- Reuse the same signature detection in `resolveImageBase64Like`.
- Add a regression test for JPEG Base64 beginning with `/9j/`.

## Impact

OpenAI-compatible image providers that return raw JPEG data through `b64_json` can now be persisted correctly instead of being treated as relative media URLs.

## Validation

- `pnpm exec vitest run src/app/api/image-tasks/image-task-support.test.ts` — 20 tests passed.
- `pnpm typecheck` — passed.
- Verified end-to-end with a real image generation response and permanent media persistence.
