### PR TITLE
修复：允许文本模型使用绑定超时配置

### DIFF
--- a/web/src/lib/server/model-request-policy.test.ts
+++ b/web/src/lib/server/model-request-policy.test.ts
@@ -9,9 +9,9 @@ describe("model request policy", () => {
         expect(resolveModelRequestTimeoutMs(undefined, "image")).toBe(10 * 60_000);
     });
 
-    it("keeps every text model attempt at three minutes", () => {
-        expect(resolveModelRequestTimeoutMs({ capabilityProfile: { timeoutMs: 15_000 } }, "text")).toBe(3 * 60_000);
-        expect(resolveModelRequestTimeoutMs({ capabilityProfile: { timeoutMs: 8 * 60_000 } }, "text")).toBe(3 * 60_000);
+    it("applies a binding timeout to text models", () => {
+        expect(resolveModelRequestTimeoutMs({ capabilityProfile: { timeoutMs: 15_000 } }, "text")).toBe(15_000);
+        expect(resolveModelRequestTimeoutMs({ capabilityProfile: { timeoutMs: 8 * 60_000 } }, "text")).toBe(8 * 60_000);
     });
 
     it("applies and bounds a binding timeout", () => {

--- a/web/src/lib/server/model-request-policy.ts
+++ b/web/src/lib/server/model-request-policy.ts
@@ -14,7 +14,6 @@ export const DEFAULT_MODEL_REQUEST_TIMEOUT_MS: Record<LogicalModelCapability, nu
 type ModelRequestPolicyConfig = { capabilityProfile?: Pick<LogicalModelCapabilityProfile, "timeoutMs"> };
 
 export function resolveModelRequestTimeoutMs(config: ModelRequestPolicyConfig | undefined, capability: LogicalModelCapability) {
-    if (capability === "text") return TEXT_MODEL_REQUEST_TIMEOUT_MS;
     const configured = Math.floor(Number(config?.capabilityProfile?.timeoutMs));
     if (!Number.isFinite(configured) || configured <= 0) return DEFAULT_MODEL_REQUEST_TIMEOUT_MS[capability];
     return Math.max(MIN_REQUEST_TIMEOUT_MS, Math.min(MAX_REQUEST_TIMEOUT_MS, configured));

--- a/web/src/lib/server/text-planning-runtime.test.ts
+++ b/web/src/lib/server/text-planning-runtime.test.ts
@@ -376,7 +376,7 @@ describe("text planning runtime protocol matrix", () => {
         await expect(requestStructuredText(requestInput(candidate("newapi")))).rejects.toThrow("文本模型规划响应超时");
     });
 
-    it("所有文本规划候选都使用三分钟超时", async () => {
+    it("文本规划候选使用绑定配置的超时", async () => {
         const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
         mockedFetch.mockResolvedValueOnce(chatJsonResponse()).mockResolvedValueOnce(chatJsonResponse());
 
@@ -384,7 +384,7 @@ describe("text planning runtime protocol matrix", () => {
         await requestStructuredText(requestInput({ ...candidate("newapi", { id: "long-reasoning" }), capabilityProfile: { timeoutMs: 8 * 60_000 } }));
 
         expect(timeoutSpy).toHaveBeenNthCalledWith(1, 3 * 60_000);
-        expect(timeoutSpy).toHaveBeenNthCalledWith(2, 3 * 60_000);
+        expect(timeoutSpy).toHaveBeenNthCalledWith(2, 8 * 60_000);
     });
 
     it("增量解析 Chat SSE 中的结构化 JSON", async () => {


### PR DESCRIPTION
## 问题

模型绑定已经支持声明 `capabilityProfile.timeoutMs`，但文本能力仍被固定为 180 秒，导致管理员为长耗时文本模型配置的超时不能生效。

## 修复

- 删除文本能力固定 180 秒的特殊分支。
- 所有能力统一优先使用绑定的 `capabilityProfile.timeoutMs`。
- 未配置时仍沿用原有默认值，文本默认仍为 3 分钟。
- 保留现有 5 秒至 30 分钟的统一资源保护边界。

该改动不涉及模型名称、供应商、协议或业务入口特判。

## 验证

- `model-request-policy` 与 `text-planning-runtime`：45 项通过。
- TypeScript 类型检查通过。
- 完整 ESLint、Prettier 和 `git diff --check` 通过。
