### PR TITLE
修复：以原始剧本为准恢复短剧对白与内容结构

### DIFF
--- a/web/src/app/api/drama/analyze/route.test.ts
+++ b/web/src/app/api/drama/analyze/route.test.ts
@@ -108,11 +108,12 @@ describe("POST /api/drama/analyze", () => {
             messages?: Array<{ role: string; content: string }>;
             stream?: boolean;
             streamFallback?: boolean;
+            allowRepair?: boolean;
             signal?: AbortSignal;
         };
         const toolBillingKey = new Headers(input.headers).get("x-vozeb-pro-points-idempotency-key");
         const fallbackBillingKey = new Headers(input.fallbackHeaders).get("x-vozeb-pro-points-idempotency-key");
-        expect(input).toMatchObject({ preferNativeTools: false, stream: true, streamFallback: true, tool: { name: "analyze_drama_content" } });
+        expect(input).toMatchObject({ preferNativeTools: false, stream: true, streamFallback: true, allowRepair: true, tool: { name: "analyze_drama_content" } });
         expect(input.signal).toBeInstanceOf(AbortSignal);
         expect(input.validateArguments?.('{"script":"输入回显"}')).toBe(false);
         expect(input.validateArguments?.('{"episode":{"outline":"大纲"},"shots":[{"title":"镜头"}]}')).toBe(true);
@@ -205,7 +206,7 @@ describe("POST /api/drama/analyze", () => {
         expect(payload.data.shots.flatMap((shot) => shot.utterances)).toEqual([expect.objectContaining({ speaker: "顾言", text: "先离开这里。" })]);
     });
 
-    it("rejects dialogue that still has no specific speaker after source normalization", async () => {
+    it("keeps unresolved source dialogue for content review instead of rejecting the episode", async () => {
         const script = "他说：“快走！”";
         mocks.requestStructuredText.mockResolvedValueOnce({
             arguments: JSON.stringify({
@@ -244,12 +245,12 @@ describe("POST /api/drama/analyze", () => {
             }),
         );
 
-        expect(response.status).toBe(502);
-        await expect(response.json()).resolves.toMatchObject({ code: 502, data: null, msg: "模型返回的剧本对白或原文不完整" });
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toMatchObject({ code: 0, data: { shots: [expect.objectContaining({ utterances: [expect.objectContaining({ speaker: "他", text: "快走！" })] })] } });
         expect(mocks.requestStructuredText).toHaveBeenCalledOnce();
     });
 
-    it("splits a malformed single eight-second response before returning it to the editor", async () => {
+    it("repairs incomplete model source text locally before returning it to the editor", async () => {
         const lines = Array.from({ length: 78 }, (_, index) => `角色${index + 1}说：“第${index + 1}句对白必须保留。”`);
         mocks.refundUserPoints.mockResolvedValue({ pointsBalance: 98 });
         const responseForSegment = (segment: string) => ({
@@ -319,13 +320,12 @@ describe("POST /api/drama/analyze", () => {
             const messages = (input as { messages: Array<{ role: string; content: string }> }).messages;
             return (JSON.parse(messages.at(-1)!.content) as { script: string }).script;
         });
-        expect(requestedScripts).toHaveLength(3);
+        expect(requestedScripts).toHaveLength(1);
         expect(requestedScripts[0]).toBe(lines.join("\n"));
-        expect(requestedScripts.slice(1).every((segment) => segment !== requestedScripts[0])).toBe(true);
-        expect(mocks.refundUserPoints).toHaveBeenCalledWith("user-one", "planner", 2, "text", 1, undefined, "points-full");
+        expect(mocks.refundUserPoints).not.toHaveBeenCalled();
     });
 
-    it("refunds successful segments when a later segment cannot be analyzed", async () => {
+    it("uses the local script when model source coverage is incomplete", async () => {
         const lines = ["角色甲说：“第一句。”", "角色乙说：“第二句。”"];
         const script = lines.join("\n");
         const segmentResponse = (segment: string, billed = false) => ({
@@ -378,9 +378,20 @@ describe("POST /api/drama/analyze", () => {
             }),
         );
 
-        expect(response.status).toBe(502);
-        expect(mocks.refundUserPoints).toHaveBeenCalledTimes(2);
-        expect(mocks.refundUserPoints.mock.calls.map((call) => call[6])).toEqual(expect.arrayContaining(["points-failed-segment", "points-segment"]));
+        const payload = (await response.json()) as { data: { shots: Array<{ sourceText: string; utterances: Array<{ text: string }> }> } };
+        expect(response.status).toBe(200);
+        expect(
+            payload.data.shots
+                .map((shot) => shot.sourceText)
+                .join("\n")
+                .replace(/\n+/g, "\n"),
+        ).toBe(script);
+        const utteranceText = payload.data.shots.flatMap((shot) => shot.utterances.map((utterance) => utterance.text));
+        expect(utteranceText).toHaveLength(2);
+        expect(utteranceText[0]).toBe("第一句。");
+        expect(utteranceText[1]).toBe("第二句。");
+        expect(mocks.requestStructuredText).toHaveBeenCalledOnce();
+        expect(mocks.refundUserPoints).not.toHaveBeenCalled();
     });
 
     it("keeps one request idempotent while separate user actions use different billing keys", async () => {

--- a/web/src/app/api/drama/analyze/route.ts
+++ b/web/src/app/api/drama/analyze/route.ts
@@ -238,12 +238,11 @@ async function analyzeDramaScriptSegment(input: Parameters<typeof analyzeDramaCo
             input.tool,
             systemAiIdempotencyKey("drama-analyze", input.userId, "content", input.requestId, segmentKey, script, input.candidate.channel.id, input.candidate.upstreamModel),
             (argumentsText) => hasUsableDramaToolArguments(argumentsText, input.tool.name),
-            false,
+            true,
             input.signal,
         );
         try {
             const parsed = JSON.parse(call.args);
-            if (!hasCompleteDramaSourceCoverage(parsed, script)) throw new Error("模型返回的剧本原文不完整");
             const data = normalizeDramaContentAnalysis(parsed, input.durationPolicy, script);
             if (!hasCompleteDramaContentAnalysis(data, script)) throw new Error("模型返回的剧本对白或原文不完整");
             calls.push(call);

--- a/web/src/lib/server/drama-analysis.test.ts
+++ b/web/src/lib/server/drama-analysis.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
     describeDramaModelOutput,
+    hasCompleteDramaContentAnalysis,
     hasCompleteDramaDialogueAttribution,
     hasUsableDramaToolArguments,
     normalizeDramaContentAnalysis,
@@ -204,7 +205,7 @@ describe("drama analysis contracts", () => {
         expect(new Set(result.shots.map((shot) => shot.description)).size).toBe(result.shots.length);
     });
 
-    it("does not treat quoted place names as dialogue and requires explicit speakers", () => {
+    it("does not treat quoted place names as dialogue while allowing speaker review", () => {
         const script = ["林照雪低声道：“忍着点，九幽冥毒深入髓海，过程会有些痛苦。”", "二人来到“涤心池”，池水泛起灵光。", "云舒咬紧牙关：“无妨，你尽管施为。”", "剑意入体，她闷哼一声：“唔……”"].join("\n");
         const base = {
             episode: { outline: "疗毒", hook: "", nextPreview: "", sourceRange: "第二章" },
@@ -260,6 +261,21 @@ describe("drama analysis contracts", () => {
         expect(hasCompleteDramaDialogueAttribution(JSON.stringify(invalid), script)).toBe(false);
         expect(hasCompleteDramaDialogueAttribution(JSON.stringify(valid), script)).toBe(true);
 
+        const pendingSpeakerReview = {
+            ...base,
+            shots: [
+                {
+                    ...shot,
+                    utterances: [
+                        { type: "dialogue", speaker: "林照雪", text: "忍着点，九幽冥毒深入髓海，过程会有些痛苦。" },
+                        { type: "dialogue", speaker: "", text: "无妨，你尽管施为。" },
+                        { type: "dialogue", speaker: "她", text: "唔……" },
+                    ],
+                },
+            ],
+        };
+        expect(hasCompleteDramaDialogueAttribution(JSON.stringify(pendingSpeakerReview), script)).toBe(true);
+
         const result = normalizeDramaContentAnalysis(valid, { defaultSeconds: 5, durationSeconds: [5, 8, 10, 15] }, script);
         expect(result.shots.flatMap((item) => item.utterances.filter((utterance) => utterance.type === "dialogue").map((utterance) => [utterance.speaker, utterance.text]))).toEqual([
             ["林照雪", "忍着点，九幽冥毒深入髓海，过程会有些痛苦。"],
@@ -300,6 +316,84 @@ describe("drama analysis contracts", () => {
 
         expect(result.shots[0].utterances).toEqual([expect.objectContaining({ speaker: "顾言", text: "先离开这里。" })]);
         expect(hasCompleteDramaDialogueAttribution(JSON.stringify(result), script)).toBe(true);
+    });
+
+    it("infers speakers around common speech verbs and object phrases", () => {
+        const script = "灯光下，顾远看见妻子不安，便放下筷子，对着她讲：“别害怕。”妻子叹了口气，望向窗外。对顾远讲：“我还是担心。”";
+        const result = normalizeDramaContentAnalysis(
+            {
+                episode: { outline: "饭后交谈", hook: "", nextPreview: "", sourceRange: "第一章" },
+                characters: [
+                    { name: "顾远", description: "丈夫" },
+                    { name: "妻子", description: "妻子" },
+                ],
+                scenes: [],
+                props: [],
+                clues: [],
+                shots: [{ title: "交谈", description: "夫妻交谈", sourceText: script, shotBoundary: "对白结束", utterances: [], duration: 8, characterNames: [], sceneName: "饭桌", propNames: [], clueNames: [] }],
+            },
+            { defaultSeconds: 5, durationSeconds: [5, 8, 10, 15] },
+            script,
+        );
+
+        expect(result.shots.flatMap((shot) => shot.utterances.map((utterance) => [utterance.speaker, utterance.text]))).toEqual([
+            ["顾远", "别害怕。"],
+            ["妻子", "我还是担心。"],
+        ]);
+        expect(hasCompleteDramaContentAnalysis(result, script)).toBe(true);
+    });
+
+    it("recovers an object-only attribution from the prior sentence without a model character roster", () => {
+        const script = "孩子的名字叫“石头”。男人讲：“别担心。”女人叹了口气，望向窗外。对男人讲：“我还是担心。”";
+        const result = normalizeDramaContentAnalysis(
+            {
+                episode: { outline: "饭后交谈", hook: "", nextPreview: "", sourceRange: "第一章" },
+                characters: [],
+                scenes: [],
+                props: [],
+                clues: [],
+                shots: [{ title: "交谈", description: "女人表达担忧", sourceText: script, shotBoundary: "对白结束", utterances: [], duration: 8, characterNames: [], sceneName: "饭桌", propNames: [], clueNames: [] }],
+            },
+            { defaultSeconds: 5, durationSeconds: [5, 8, 10, 15] },
+            script,
+        );
+
+        expect(result.shots.flatMap((shot) => shot.utterances.map((utterance) => [utterance.speaker, utterance.text]))).toEqual([
+            ["男人", "别担心。"],
+            ["女人", "我还是担心。"],
+        ]);
+        expect(hasCompleteDramaContentAnalysis(result, script)).toBe(true);
+    });
+
+    it("keeps the local script authoritative when model source text or utterances drift", () => {
+        const script = "顾言说道：“先走。”风雪压过城门。";
+        const result = normalizeDramaContentAnalysis(
+            {
+                episode: { outline: "离城" },
+                characters: [{ name: "顾言", description: "守城人" }],
+                shots: [
+                    {
+                        title: "城门",
+                        description: "顾言离开城门",
+                        sourceText: "顾言离开。",
+                        dialogue: "顾言表示必须马上离开。",
+                        utterances: [
+                            { type: "dialogue", speaker: "顾言", text: "先走。" },
+                            { type: "dialogue", speaker: "顾言", text: "风雪压过城门。" },
+                        ],
+                        duration: 5,
+                    },
+                ],
+            },
+            5,
+            script,
+        );
+
+        const utteranceText = result.shots.flatMap((shot) => shot.utterances.map((utterance) => utterance.text));
+        expect(result.shots.map((shot) => shot.sourceText).join("")).toBe(script);
+        expect(utteranceText).toHaveLength(1);
+        expect(utteranceText[0]).toBe("先走。");
+        expect(hasCompleteDramaContentAnalysis(result, script)).toBe(true);
     });
 
     it("only accepts visual fields for reviewed shot ids", () => {
@@ -382,7 +476,7 @@ describe("drama analysis contracts", () => {
 
     it("rejects echoed input and empty structured results", () => {
         expect(hasUsableDramaToolArguments('{"script":"原始剧本","summary":"简介"}', "analyze_drama_content")).toBe(false);
-        expect(hasUsableDramaToolArguments('{"episode":{"outline":"大纲"},"shots":[{"title":"镜头一"}]}', "analyze_drama_content")).toBe(true);
+        expect(hasUsableDramaToolArguments('{"shots":[{"title":"镜头一"}]}', "analyze_drama_content")).toBe(true);
         expect(hasUsableDramaToolArguments('{"shots":[{"shotId":"shot-one"}]}', "design_drama_visuals")).toBe(true);
     });
 

--- a/web/src/lib/server/drama-analysis.ts
+++ b/web/src/lib/server/drama-analysis.ts
@@ -6,11 +6,15 @@ import { strictJsonObjectText } from "@/lib/server/structured-model-output";
 
 export function normalizeDramaContentAnalysis(value: unknown, durationPolicy: number | DramaShotDurationPolicy, sourceScript = ""): DramaContentAnalysis {
     const source = object(value);
+    const sourceCharacterNames = array(source.characters)
+        .map((item) => text(object(item).name))
+        .filter(Boolean);
     const rawShots = array(source.shots).flatMap((item, index) => {
         const shot = object(item);
         const sourceText = text(shot.sourceText);
-        const description = text(shot.description) || sourceText;
-        if (!sourceText || !description) return [];
+        const title = text(shot.title) || `镜头 ${String(index + 1).padStart(2, "0")}`;
+        const description = text(shot.description) || sourceText || title;
+        if (!sourceText && !sourceScript) return [];
         const modelUtterances = array(shot.utterances).flatMap((value, utteranceIndex) => {
             const utterance = object(value);
             const utteranceText = text(utterance.text);
@@ -26,8 +30,8 @@ export function normalizeDramaContentAnalysis(value: unknown, durationPolicy: nu
             ];
         });
         const characterNames = texts(shot.characterNames);
-        const mergedUtterances = mergeUtterances(extractDramaUtterances(sourceText, characterNames), modelUtterances, sourceText);
-        const dialogue = normalizeDialogue(extractQuotedDialogue(sourceText) || shot.dialogue, mergedUtterances);
+        const mergedUtterances = mergeUtterances(extractDramaUtterances(sourceText, [...new Set([...characterNames, ...sourceCharacterNames])]), modelUtterances);
+        const dialogue = normalizeDialogue(sourceScript ? "" : extractQuotedDialogue(sourceText) || shot.dialogue, mergedUtterances);
         const narration =
             text(shot.narration) ||
             mergedUtterances
@@ -37,7 +41,7 @@ export function normalizeDramaContentAnalysis(value: unknown, durationPolicy: nu
         const utterances = ensureUtteranceCoverage(mergedUtterances, dialogue, narration);
         return [
             {
-                title: text(shot.title) || `镜头 ${String(index + 1).padStart(2, "0")}`,
+                title,
                 description,
                 sourceText,
                 shotBoundary: text(shot.shotBoundary) || "动作或叙事节拍变化",
@@ -52,7 +56,7 @@ export function normalizeDramaContentAnalysis(value: unknown, durationPolicy: nu
             },
         ];
     });
-    const coveredShots = restoreMissingDialogueCoverage(restoreSourceTextCoverage(rawShots, sourceScript), sourceScript);
+    const coveredShots = restoreMissingDialogueCoverage(restoreSourceTextCoverage(rawShots, sourceScript), sourceScript, sourceCharacterNames);
     const shots = coveredShots.flatMap((shot) => splitDramaContentShot(shot, resolveDramaShotDurations(Math.max(shot.duration, estimateDramaSpokenDuration(shot)), durationPolicy)));
     return {
         episode: {
@@ -279,8 +283,9 @@ export function hasUsableDramaToolArguments(value: string, toolName: string) {
     try {
         const source = object(JSON.parse(value));
         if ("script" in source || "summary" in source) return false;
-        if (!array(source.shots).length) return false;
-        return toolName !== "analyze_drama_content" || Object.keys(object(source.episode)).length > 0;
+        const shots = array(source.shots).map(object);
+        if (!shots.length) return false;
+        return toolName !== "analyze_drama_content" || shots.some((shot) => text(shot.title) || text(shot.description) || text(shot.sourceText) || array(shot.utterances).length);
     } catch {
         return false;
     }
@@ -321,7 +326,7 @@ export function hasCompleteDramaDialogueAttribution(value: string, sourceScript:
                 .map(object)
                 .filter((utterance) => utterance.type === "dialogue"),
         );
-        if (modelDialogue.some((utterance) => !isSpecificDramaSpeaker(text(utterance.speaker)) || !text(utterance.text))) return false;
+        if (modelDialogue.some((utterance) => !text(utterance.text))) return false;
         if (modelDialogue.some((utterance) => !sourceDialogue.some((span) => sameDialogue(span.text, text(utterance.text))))) return false;
         const remaining = [...modelDialogue];
         return sourceDialogue.every((span) => {
@@ -492,7 +497,7 @@ type DialogueSpan = {
 };
 
 const narrativeDialoguePattern = /^[^。！？!?]{0,24}(?:说明|表示|告知|询问|讲述|描述|解释|透露|提到|认为|发现|来到|进入|看见|感到|回忆|想起|请求|劝说)(?:自己|对方|她|他|其|，|,)/u;
-const speechVerbPattern = /(?:说|说道|问|问道|回答|答道|开口|喊|叫|低声道|轻声道|呢喃|嘀咕|回应|回道|回了?一句|应道|接话|追问|反问|提醒|安慰|解释道|补充道|笑道|哭道|吼道|骂道|想说)\s*$/u;
+const speechVerbPattern = /(?:说|说道|讲|讲道|告诉|问|问道|回答|答道|开口|喊|叫|嚷|嚷道|低声道|轻声道|呢喃|念叨|嘀咕|回应|回道|回了?一句|应道|接话|追问|反问|提醒|安慰|解释道|补充道|笑道|哭道|吼道|骂道|想说)\s*$/u;
 
 function extractQuotedDialogue(value: string) {
     return extractDialogueSpans(value)
@@ -566,23 +571,50 @@ function inferDialogueSpeaker(before: string, after: string, knownSpeakers: stri
 }
 
 function inferSpeaker(value: string, knownSpeakers: string[] = []) {
-    const sentence =
-        value
-            .split(/[。！？!?；;\n]/)
-            .pop()
-            ?.trim() || "";
-    const verbMatch = sentence.match(/(?:说|说道|问|问道|回答|答道|开口|喊|叫|低声道|轻声道|呢喃|嘀咕|回应|回道|回了?一句|应道|接话|追问|反问|提醒|安慰|解释道|补充道|笑道|哭道|吼道|骂道|想说)\s*[：:]?\s*$/u);
+    const sentences = value
+        .split(/[。！？!?；;\n]/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+    const sentence = sentences.at(-1) || "";
+    if (/(?:名字|姓名|称呼|人称)\s*叫\s*$/u.test(sentence)) return "";
+    const verbMatch = sentence.match(/(?:说|说道|讲|讲道|告诉|问|问道|回答|答道|开口|喊|叫|嚷|嚷道|低声道|轻声道|呢喃|念叨|嘀咕|回应|回道|回了?一句|应道|接话|追问|反问|提醒|安慰|解释道|补充道|笑道|哭道|吼道|骂道|想说)\s*[：:]?\s*$/u);
     if (!verbMatch?.index) return "";
     const subject = sentence
         .slice(0, verbMatch.index)
         .replace(/(?:又|再|再次|缓缓|轻轻|低声|轻声|小声|忍不住|刚想|终于|随即|立即|赶紧|回了?一句)+$/u, "")
         .trim();
-    const compactSubject = subject.split(/[，,]/).pop()?.trim().replace(/^.*的/u, "") || "";
-    const knownSpeaker = nearestKnownSpeaker(compactSubject, knownSpeakers);
+    const speakerSubject = subject.replace(/[，,]?(?:对|向|冲|朝|跟)(?:着)?[^，,。！？!?；;]{0,24}$/u, "").trim();
+    const compactSubject = speakerSubject.split(/[，,]/).pop()?.trim().replace(/^.*的/u, "") || "";
+    const knownSpeaker = nearestKnownSpeaker(compactSubject, knownSpeakers) || leadingKnownSpeaker(speakerSubject, knownSpeakers) || firstKnownSpeaker(speakerSubject, knownSpeakers);
     if (knownSpeaker) return knownSpeaker;
-    const leadingSpeaker = compactSubject.match(/^(他|她|男人|女人|老人|女孩|男孩|医生|护士|[\p{Script=Han}]{2,4})(?=闭|睁|抬|低|看|走|站|坐|转|笑|哭|皱|摇|点|伸|捂|扶|推|拉|拿|压|咬|忍|哼|喘|叹|惊|快|刚|又|再|缓|轻|小|随|立|赶)/u)?.[1];
+    if (/^(?:对|向|冲|朝|跟)(?:着)?/u.test(subject)) {
+        const previousSentence = sentences.at(-2) || "";
+        const previousSpeaker = leadingKnownSpeaker(previousSentence, knownSpeakers) || firstKnownSpeaker(previousSentence, knownSpeakers) || leadingNarrativeSpeaker(previousSentence);
+        if (previousSpeaker) return previousSpeaker;
+    }
+    const leadingSpeaker = leadingNarrativeSpeaker(compactSubject);
     if (leadingSpeaker) return leadingSpeaker;
     return compactSubject.match(/[\p{Script=Han}A-Za-z0-9·]{1,12}$/u)?.[0] || "";
+}
+
+function leadingNarrativeSpeaker(value: string) {
+    return value.match(/(?:^|[，,])\s*[”"」』]?(他|她|男人|女人|老人|女孩|男孩|医生|护士|[\p{Script=Han}]{2,4}?)(?=闭|睁|抬|低|看|走|站|坐|转|笑|哭|皱|摇|点|伸|捂|扶|推|拉|拿|压|咬|忍|哼|喘|叹|惊|快|刚|又|再|缓|轻|小|随|立|赶)/u)?.[1] || "";
+}
+
+function leadingKnownSpeaker(value: string, knownSpeakers: string[]) {
+    return [...knownSpeakers]
+        .sort((left, right) => right.length - left.length)
+        .find((name) => {
+            const index = value.indexOf(name);
+            return index >= 0 && index <= 2;
+        });
+}
+
+function firstKnownSpeaker(value: string, knownSpeakers: string[]) {
+    return knownSpeakers.reduce<{ name: string; index: number } | undefined>((first, name) => {
+        const index = value.indexOf(name);
+        return index >= 0 && (!first || index < first.index) ? { name, index } : first;
+    }, undefined)?.name;
 }
 
 function inferFollowingSpeaker(value: string, knownSpeakers: string[]) {
@@ -608,20 +640,14 @@ function looksLikeSpokenQuote(value: string, before: string) {
     return /[。！？!?…]$/u.test(value.trim()) || /[：:]\s*$/u.test(before);
 }
 
-function mergeUtterances(sourceUtterances: DramaUtterance[], modelUtterances: DramaUtterance[], sourceText: string) {
-    const merged = sourceUtterances.map((item) => {
+function mergeUtterances(sourceUtterances: DramaUtterance[], modelUtterances: DramaUtterance[]) {
+    return sourceUtterances.map((item, index) => {
         const model = modelUtterances.find((candidate) => sameDialogue(candidate.text, item.text));
-        return model && isSpecificDramaSpeaker(model.speaker) ? { ...item, speaker: model.speaker } : item;
+        return { ...(model && isSpecificDramaSpeaker(model.speaker) ? { ...item, speaker: model.speaker } : item), order: index + 1 };
     });
-    for (const item of modelUtterances) {
-        if (item.type === "dialogue" && (narrativeDialoguePattern.test(item.text) || !isSpecificDramaSpeaker(item.speaker) || !dialogueKey(sourceText).includes(dialogueKey(item.text)))) continue;
-        if (merged.some((candidate) => sameDialogue(candidate.text, item.text))) continue;
-        merged.push(item);
-    }
-    return merged.map((item, index) => ({ ...item, order: index + 1 }));
 }
 
-function restoreMissingDialogueCoverage(shots: DramaContentAnalysis["shots"], sourceScript: string) {
+function restoreMissingDialogueCoverage(shots: DramaContentAnalysis["shots"], sourceScript: string, characterNames: string[] = []) {
     const script = sourceScript.trim();
     if (!script || !shots.length) return shots;
     const covered = new Map<string, number>();
@@ -635,7 +661,7 @@ function restoreMissingDialogueCoverage(shots: DramaContentAnalysis["shots"], so
     const matched = new Map<string, number>();
     const positions = locateShotPositions(script, shots);
     const result = shots.map((shot) => ({ ...shot, utterances: [...shot.utterances] }));
-    const knownSpeakers = shots.flatMap((shot) => shot.characterNames);
+    const knownSpeakers = [...new Set([...characterNames, ...shots.flatMap((shot) => shot.characterNames)])];
     for (const span of extractDialogueSpans(script, knownSpeakers)) {
         const key = dialogueKey(span.text);
         if (!key) continue;


### PR DESCRIPTION
## 问题

模型分段分析可能遗漏或改写镜头 sourceText、把叙述误判为对白，或者返回概括式 shot.dialogue。此前这些模型输出会参与原文完整性校验，导致原始剧本实际完整却被判定为“对白或原文不完整”。

## 修复

- 存在 sourceScript 时，以平台保存的完整原始剧本作为 sourceText 和对白集合的唯一权威。
- 模型 utterances 仅用于为本地原文对白补充说话人，不再新增模型误判、改写或幻觉对白。
- 模型 sourceText 缺失或不完整时，按镜头数量和相对位置从完整原文恢复。
- 从紧邻叙述上下文恢复常见发言动词与省略主语，同时排除“名字/姓名/称呼 + 叫”等非对白引号。
- 无法可靠识别具体人物时保留原文对白供内容审核编辑；仍严格拒绝缺失对白文本、模型杜撰对白和原文覆盖不全。
- 没有 sourceScript 的旧调用语义保持不变。

不包含模型、供应商、小说或项目专用分支。

## 验证

- `drama-analysis` 与短剧分析路由：28 项通过。
- TypeScript 类型检查通过。
- 完整 ESLint、Prettier 和 `git diff --check` 通过。
