### PR TITLE
修复：区分文本流式降级计费身份

### DIFF
--- a/web/src/lib/server/text-planning-runtime.test.ts
+++ b/web/src/lib/server/text-planning-runtime.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SystemChannelAdvancedConfig, SystemModelChannel } from "@/lib/auth/store";
 import { fetchInternalApi } from "@/lib/server/internal-origin";
+import { systemAiBillingHeaders } from "@/lib/server/system-ai-billing";
 import { getTextPlanningRuntime, isStructuredTextFailure, rankTextPlanningCandidates, requestStructuredText, resetTextPlanningRuntime, type TextPlanningCandidate } from "./text-planning-runtime";
 
 vi.mock("@/lib/server/internal-origin", () => ({ fetchInternalApi: vi.fn() }));
@@ -475,12 +476,25 @@ describe("text planning runtime protocol matrix", () => {
     it("流式请求被渠道拒绝时回退一次完整 JSON 请求", async () => {
         mockedFetch.mockResolvedValueOnce(new Response("stream unsupported", { status: 422 })).mockResolvedValueOnce(chatJsonResponse());
 
-        await expect(requestStructuredText({ ...requestInput(candidate("newapi")), headers: { "idempotency-key": "stream-fallback" }, stream: true })).resolves.toMatchObject({ arguments: "{}" });
+        await expect(
+            requestStructuredText({
+                ...requestInput(candidate("newapi")),
+                headers: { "idempotency-key": "stream-fallback" },
+                fallbackHeaders: {
+                    "idempotency-key": "stream-fallback",
+                    ...systemAiBillingHeaders("planner", "billing-json", "model-one"),
+                },
+                stream: true,
+            }),
+        ).resolves.toMatchObject({ arguments: "{}" });
         expect(mockedFetch).toHaveBeenCalledTimes(2);
         expect(JSON.parse(String(mockedFetch.mock.calls[0]?.[1]?.body))).toMatchObject({ stream: true });
         expect(JSON.parse(String(mockedFetch.mock.calls[1]?.[1]?.body))).not.toHaveProperty("stream");
         expect(new Headers(mockedFetch.mock.calls[0]?.[1]?.headers).get("idempotency-key")).toContain(":chat-json-stream");
         expect(new Headers(mockedFetch.mock.calls[1]?.[1]?.headers).get("idempotency-key")).toContain(":chat-json");
+        expect(new Headers(mockedFetch.mock.calls[0]?.[1]?.headers).get("x-vozeb-pro-points-idempotency-key")).toBe("billing-json");
+        expect(new Headers(mockedFetch.mock.calls[1]?.[1]?.headers).get("x-vozeb-pro-points-idempotency-key")).toBe("billing-json:stream-fallback");
+        expect(new Headers(mockedFetch.mock.calls[0]?.[1]?.headers).get("x-vozeb-pro-points-signature")).not.toBe(new Headers(mockedFetch.mock.calls[1]?.[1]?.headers).get("x-vozeb-pro-points-signature"));
     });
 });
 

--- a/web/src/lib/server/text-planning-runtime.ts
+++ b/web/src/lib/server/text-planning-runtime.ts
@@ -104,7 +104,13 @@ export async function requestStructuredText(input: StructuredTextRequest): Promi
                 return await readStructuredResponse(input, request, response, startedAt);
             } catch (error) {
                 if (input.stream && input.streamFallback !== false && index === 0 && shouldFallbackFromStream(error)) {
-                    const fallback = await requestStructuredText({ ...input, stream: false, streamFallback: false });
+                    const fallback = await requestStructuredText({
+                        ...input,
+                        headers: streamFallbackHeaders(input.headers, input.candidate.upstreamModel),
+                        fallbackHeaders: streamFallbackHeaders(input.fallbackHeaders, input.candidate.upstreamModel),
+                        stream: false,
+                        streamFallback: false,
+                    });
                     return { ...fallback, fallbackReason: error instanceof Error ? error.message : "上游不支持流式规划" };
                 }
                 if (index === requests.length - 1 || (!shouldFallbackFromNativeTool(error, request) && !shouldRepairStructuredResponse(error, request))) throw error;
@@ -273,6 +279,16 @@ function repairRequestHeaders(input: StructuredTextRequest) {
     const upstreamModel = headers.get(SYSTEM_AI_UPSTREAM_MODEL_HEADER)?.trim() || input.candidate.upstreamModel;
     if (!logicalModel || !businessRequestId) return headers;
     Object.entries(systemAiBillingHeaders(logicalModel, `${businessRequestId}:repair`, upstreamModel)).forEach(([name, value]) => headers.set(name, value));
+    return headers;
+}
+
+function streamFallbackHeaders(source: HeadersInit | undefined, candidateUpstreamModel: string) {
+    if (!source) return undefined;
+    const headers = new Headers(source);
+    const logicalModel = headers.get(SYSTEM_AI_LOGICAL_MODEL_HEADER)?.trim();
+    const businessRequestId = headers.get(SYSTEM_AI_POINTS_IDEMPOTENCY_HEADER)?.trim();
+    const upstreamModel = headers.get(SYSTEM_AI_UPSTREAM_MODEL_HEADER)?.trim() || candidateUpstreamModel;
+    if (logicalModel && businessRequestId) Object.entries(systemAiBillingHeaders(logicalModel, `${businessRequestId}:stream-fallback`, upstreamModel)).forEach(([name, value]) => headers.set(name, value));
     return headers;
 }
 


### PR DESCRIPTION
## 问题

结构化文本请求在流式调用失败后，会递归降级为非流式调用。降级前后请求体的 stream 参数不同，但此前继续复用同一个已签名的积分业务请求 ID，导致积分代理检测到“幂等键相同、请求参数不同”并返回冲突。

## 修复

- 仅在发生 stream fallback 时派生独立的 `:stream-fallback` 业务身份。
- 使用派生身份重新生成系统 AI 计费签名。
- 正常单次请求、模型与渠道选择、协议路由、退款和既有幂等保护保持不变。

## 验证

- `text-planning-runtime.test.ts`：40 项通过。
- TypeScript 类型检查通过。
- 完整 ESLint、Prettier 和 `git diff --check` 通过。
