### PR TITLE
测试：隔离本地媒体夹具的系统代理

### DIFF
--- a/web/src/lib/server/active-protocol-media-matrix.live.test.ts
+++ b/web/src/lib/server/active-protocol-media-matrix.live.test.ts
@@ -11,6 +11,8 @@ import type { VideoTask } from "@/lib/server/video-task-store";
 import { queryVideoTaskUpstream } from "@/lib/server/video-task-runtime";
 import { createProtocolFixtureServer } from "../../../scripts/protocol-fixture-server.mjs";
 
+vi.mock("@/lib/server/proxy-dispatcher", () => ({ configureServerProxyDispatcher: vi.fn() }));
+
 const MULTIPLIERS = { imageQuality: { auto: 1, high: 1 }, videoQuality: { "720": 1, "1080": 1 }, videoSeconds: { "5": 1, "8": 1 } };
 const STRICT_IMAGE_PROTOCOLS = registeredChannelProtocolDefinitions.filter((definition) => definition.strict && definition.operations.image);
 const STRICT_VIDEO_PROTOCOLS = registeredChannelProtocolDefinitions.filter((definition) => definition.strict && definition.operations.video);


### PR DESCRIPTION
## 问题

Windows 配置系统代理时，本地 TCP 协议媒体矩阵会把 127.0.0.1 夹具请求发送到外部代理，导致稳定出现超时或媒体回读失败。该问题会让本地完整发布门禁误报 28 项协议回归。

## 修复

- 仅在 active-protocol-media-matrix.live.test.ts 中 mock 现有代理初始化入口。
- 本地协议夹具继续直接访问自身启动的 127.0.0.1 服务。
- 不修改生产代理、媒体协议、请求路由或运行时代码。

## 验证

- 协议媒体矩阵：40/40 通过。
- 完整 pnpm -C web run check:release 通过：
  - 547 个测试文件通过，4 个跳过。
  - 2651 项测试通过，9 项跳过。
  - 依赖审计、ESLint、Prettier、TypeScript、Next.js 生产构建及 Standalone 完整性全部通过。

I have read and agree to CLA.md.