### PR TITLE
修复：校验 Agent 创作模式并完善生成状态

### DIFF
--- a/web/e2e/creative-video-result.spec.ts
+++ b/web/e2e/creative-video-result.spec.ts
@@ -256,6 +256,27 @@ test("a long-running media task uses warm elapsed-time feedback", async ({ page 
     }
 });
 
+test("a paused media task shows its concrete review reason without a loading state", async ({ page }, testInfo) => {
+    await preparePage(page, testInfo);
+    const reason = "OpenAI 视频协议最多支持 1 张参考图";
+    const fixture = await mockPendingCreativeRound(page, "video", reason);
+
+    try {
+        await page.goto(`/create?conversationId=${fixture.id}`, { waitUntil: "domcontentloaded" });
+        const round = page.getByTestId("creative-media-round");
+        await expect(round.getByRole("heading", { name: "任务已暂停" })).toBeVisible({ timeout: 45_000 });
+        await expect(round.getByTestId("creative-generation-review")).toHaveText(reason);
+        await expect(round.getByTestId("creative-generation-waiting")).toHaveCount(0);
+        await expect(round.getByTestId("creative-media-loading")).toHaveCount(0);
+        await expect(round.getByText(/正在生成|已等待/)).toHaveCount(0);
+        await expect(round.getByRole("button", { name: "直接重试本次创作" })).toHaveCount(0);
+        await expectNoHorizontalOverflow(page);
+        await captureResult(round, testInfo, "creative-generation-paused-review");
+    } finally {
+        fixture.releaseEvents();
+    }
+});
+
 test("single video results keep real ratios and retain complete player controls", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== "chromium", "桌面视频尺寸矩阵由 1672×941 基准项目验证");
     await preparePage(page, testInfo);
@@ -730,7 +751,7 @@ async function mockCreativeRound(page: Page, options: { type: MediaType; sizes: 
     };
 }
 
-async function mockPendingCreativeRound(page: Page, type: MediaType) {
+async function mockPendingCreativeRound(page: Page, type: MediaType, reviewReason = "") {
     const id = `e2e-pending-${randomUUID()}`;
     const runId = `e2e-pending-run-${randomUUID()}`;
     const timestamp = Date.now();
@@ -755,13 +776,13 @@ async function mockPendingCreativeRound(page: Page, type: MediaType) {
         conversationId: id,
         inputMessageId: userMessage.id,
         assistantMessageId: assistantMessage.id,
-        status: "running",
+        status: reviewReason ? "paused" : "running",
         prompt,
         referencedAssetIds: [],
         requestedModelIds: [`${type}-gen`],
         generationPreferences: type === "image" ? { mode: "image", image: { size: "1:1", quality: "high" } } : { mode: "video", video: { size: "16:9", quality: "high", seconds: 15 } },
         assetIds: [],
-        tasks: [{ id: `${type}-task`, title: `${type === "image" ? "图片" : "视频"}生成`, type, model: `${type}-gen`, status: "running" }],
+        tasks: [{ id: `${type}-task`, title: `${type === "image" ? "图片" : "视频"}生成`, type, model: `${type}-gen`, status: reviewReason ? "needs_review" : "running", ...(reviewReason ? { error: reviewReason } : {}) }],
         createdAt: startedAt,
         updatedAt: timestamp,
     };

--- a/web/e2e/responsive.spec.ts
+++ b/web/e2e/responsive.spec.ts
@@ -71,8 +71,13 @@ async function mockAgentConversationSwitchRace(page: Page) {
         inputMessageId: "e2e-running-user",
         assistantMessageId: "e2e-running-assistant",
         status: "running",
+        requestedModelIds: ["e2e-image-model", "e2e-video-model"],
+        generationPreferences: { mode: "image", image: { size: "1:1", quality: "high", count: 2 }, video: { size: "16:9", quality: "720P", seconds: 10, count: 2 } },
         assetIds: [],
-        tasks: [{ id: "e2e-running-task", title: "生成图片", type: "image", status: "running" }],
+        tasks: [
+            { id: "e2e-running-image", title: "生成图片", type: "image", model: "e2e-image-model", ratio: "1:1", quality: "high", count: 2, status: "running" },
+            { id: "e2e-running-video", title: "生成视频", type: "video", model: "e2e-video-model", ratio: "16:9", quality: "720P", seconds: 10, count: 2, status: "running" },
+        ],
         createdAt: timestamp,
         updatedAt: timestamp + 1,
     };
@@ -783,6 +788,17 @@ test("switching conversations keeps the previous Agent run isolated and resumabl
     await page.goto(`/create?conversationId=${fixture.conversationA.id}`, { waitUntil: "domcontentloaded" });
     await waitForCreativeComposerReady(page);
     await expect(page.getByText("A 对话正在生成海报", { exact: true })).toBeVisible();
+    await expect(page.getByTestId("creative-media-loading")).toHaveCount(4);
+    await expect(page.locator('[data-testid="creative-media-loading"][data-loading-type="image"]')).toHaveCount(2);
+    await expect(page.locator('[data-testid="creative-media-loading"][data-loading-type="video"]')).toHaveCount(2);
+    await expect(page.getByLabel("本轮创作参数")).toContainText("e2e-image-model + e2e-video-model");
+    await expect(page.getByLabel("本轮创作参数")).toContainText("4个结果");
+    for (const loader of await page.getByTestId("creative-media-loading").all()) {
+        const bounds = await loader.evaluate((element) => element.getBoundingClientRect().toJSON());
+        expect(bounds.width).toBeGreaterThan(0);
+        expect(bounds.height).toBeGreaterThan(0);
+    }
+    await expectNoHorizontalOverflow(page, "concurrent image and video loading");
     await fixture.delayedRunRequested;
 
     let history = await openCreativeHistory(page);

--- a/web/src/app/(user)/create/components/creative-composer-video-mode.test.ts
+++ b/web/src/app/(user)/create/components/creative-composer-video-mode.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { applyAgentGenerationCapability, shouldShowVideoFrameControls } from "./creative-composer-video-mode";
+import { applyAgentGenerationCapability, generationPreferencesAfterSubmit, generationPreferencesForSelectedSkill, shouldShowVideoFrameControls } from "./creative-composer-video-mode";
 
 describe("shouldShowVideoFrameControls", () => {
     it("shows first and last frame slots for explicit video mode", () => {
@@ -21,5 +21,16 @@ describe("shouldShowVideoFrameControls", () => {
     it("makes the edited Agent parameter capability immediately effective", () => {
         expect(applyAgentGenerationCapability("agent", "video", { image: { quality: "high" } })).toEqual({ mode: "video", image: { quality: "high" } });
         expect(applyAgentGenerationCapability("image", "video", { mode: "image" })).toEqual({ mode: "image" });
+    });
+
+    it("drops a stale incompatible mode when a Skill is selected", () => {
+        expect(generationPreferencesForSelectedSkill({ mode: "video", video: { seconds: 5, referenceMode: "first_frame", firstFrameAssetId: "asset-one" } }, ["image", "canvas"])).toEqual({
+            video: { seconds: 5, referenceMode: "reference", firstFrameAssetId: undefined, lastFrameAssetId: undefined },
+        });
+    });
+
+    it("resets Agent preferences after each submitted turn", () => {
+        expect(generationPreferencesAfterSubmit("agent", { mode: "video", video: { seconds: 5 } })).toEqual({});
+        expect(generationPreferencesAfterSubmit("video", { mode: "video", video: { seconds: 5, firstFrameAssetId: "asset-one" } })).toEqual({ mode: "video", video: { seconds: 5, firstFrameAssetId: undefined, lastFrameAssetId: undefined } });
     });
 });

--- a/web/src/app/(user)/create/components/creative-composer-video-mode.ts
+++ b/web/src/app/(user)/create/components/creative-composer-video-mode.ts
@@ -1,4 +1,4 @@
-import type { CreativeGenerationMode, CreativeGenerationPreferences } from "@/lib/creative-runtime-contract";
+import { agentSkillSupportsGenerationMode, type CreativeGenerationMode, type CreativeGenerationPreferences } from "@/lib/creative-runtime-contract";
 
 export function shouldShowVideoFrameControls(creationMode: "agent" | CreativeGenerationMode, preferences: CreativeGenerationPreferences) {
     const effectiveMode = creationMode === "agent" ? preferences.mode : creationMode;
@@ -7,4 +7,17 @@ export function shouldShowVideoFrameControls(creationMode: "agent" | CreativeGen
 
 export function applyAgentGenerationCapability(creationMode: "agent" | CreativeGenerationMode, capability: CreativeGenerationMode, preferences: CreativeGenerationPreferences) {
     return creationMode === "agent" ? { ...preferences, mode: capability } : preferences;
+}
+
+export function generationPreferencesForSelectedSkill(preferences: CreativeGenerationPreferences, workspaces?: readonly string[]) {
+    if (!preferences.mode || agentSkillSupportsGenerationMode(workspaces, preferences.mode)) return preferences;
+    const next = { ...preferences };
+    delete next.mode;
+    if (preferences.mode === "video" && next.video) next.video = { ...next.video, referenceMode: "reference", firstFrameAssetId: undefined, lastFrameAssetId: undefined };
+    return next;
+}
+
+export function generationPreferencesAfterSubmit(creationMode: "agent" | CreativeGenerationMode, preferences: CreativeGenerationPreferences) {
+    if (creationMode === "agent") return {};
+    return preferences.video ? { ...preferences, video: { ...preferences.video, firstFrameAssetId: undefined, lastFrameAssetId: undefined } } : preferences;
 }

--- a/web/src/app/(user)/create/components/creative-generation-waiting.test.tsx
+++ b/web/src/app/(user)/create/components/creative-generation-waiting.test.tsx
@@ -46,6 +46,21 @@ describe("creative generation waiting", () => {
         expect(slots.map((slot) => slot.model)).toEqual(["image-model", "image-model", "video-model", "video-model"]);
     });
 
+    it("shows a generic loading slot before planning has created media tasks", () => {
+        expect(creativeMediaLoadingSlots(undefined)).toEqual([{ key: "pending-planning", type: "planning", title: "正在规划创作" }]);
+        expect(
+            creativeMediaLoadingSlots({
+                id: "planning-run",
+                conversationId: "conversation",
+                inputMessageId: "user",
+                assistantMessageId: "assistant",
+                status: "planning",
+                assetIds: [],
+                tasks: [],
+            }),
+        ).toEqual([{ key: "planning-run-planning", type: "planning", title: "正在规划创作" }]);
+    });
+
     it("removes the last fallback loading slot after its result is ready", () => {
         const run = {
             id: "planning-run",

--- a/web/src/app/(user)/create/components/creative-generation-waiting.test.tsx
+++ b/web/src/app/(user)/create/components/creative-generation-waiting.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { creativeGenerationWaitingCopy, formatCreativeWaitingTime } from "./creative-generation-waiting";
+import { creativeGenerationWaitingCopy, creativeMediaLoadingSlots, formatCreativeWaitingTime } from "./creative-generation-waiting";
 
 describe("creative generation waiting", () => {
     it("uses the real task phase before elapsed-time comfort copy", () => {
@@ -23,5 +23,41 @@ describe("creative generation waiting", () => {
         expect(formatCreativeWaitingTime(42)).toBe("42秒");
         expect(formatCreativeWaitingTime(72)).toBe("1分12秒");
         expect(formatCreativeWaitingTime(3_661)).toBe("1小时1分1秒");
+    });
+
+    it("creates one independent loading slot for each pending image and video result", () => {
+        const run = {
+            id: "run",
+            conversationId: "conversation",
+            inputMessageId: "user",
+            assistantMessageId: "assistant",
+            status: "running" as const,
+            assetIds: [],
+            tasks: [
+                { id: "images", title: "生成图片", type: "image" as const, model: "image-model", count: 3, status: "running" as const },
+                { id: "videos", title: "生成视频", type: "video" as const, model: "video-model", count: 2, status: "running" as const },
+            ],
+        };
+
+        const slots = creativeMediaLoadingSlots(run, [{ type: "image", status: "ready" }]);
+
+        expect(slots).toHaveLength(4);
+        expect(slots.map((slot) => slot.type)).toEqual(["image", "image", "video", "video"]);
+        expect(slots.map((slot) => slot.model)).toEqual(["image-model", "image-model", "video-model", "video-model"]);
+    });
+
+    it("removes the last fallback loading slot after its result is ready", () => {
+        const run = {
+            id: "planning-run",
+            conversationId: "conversation",
+            inputMessageId: "user",
+            assistantMessageId: "assistant",
+            status: "running" as const,
+            generationPreferences: { mode: "image" as const, image: { count: 1 } },
+            assetIds: [],
+            tasks: [],
+        };
+
+        expect(creativeMediaLoadingSlots(run, [{ type: "image", status: "ready" }])).toEqual([]);
     });
 });

--- a/web/src/app/(user)/create/components/creative-generation-waiting.test.tsx
+++ b/web/src/app/(user)/create/components/creative-generation-waiting.test.tsx
@@ -75,4 +75,18 @@ describe("creative generation waiting", () => {
 
         expect(creativeMediaLoadingSlots(run, [{ type: "image", status: "ready" }])).toEqual([]);
     });
+
+    it("does not render loading slots for a task waiting for manual review", () => {
+        expect(
+            creativeMediaLoadingSlots({
+                id: "paused-run",
+                conversationId: "conversation",
+                inputMessageId: "user",
+                assistantMessageId: "assistant",
+                status: "paused",
+                assetIds: [],
+                tasks: [{ id: "video", title: "生成视频", type: "video", status: "needs_review", error: "视频协议最多支持 1 张参考图" }],
+            }),
+        ).toEqual([]);
+    });
 });

--- a/web/src/app/(user)/create/components/creative-generation-waiting.tsx
+++ b/web/src/app/(user)/create/components/creative-generation-waiting.tsx
@@ -3,14 +3,15 @@
 import { Sparkles } from "lucide-react";
 import { useEffect, useState } from "react";
 
-import type { CreativeMessage } from "@/lib/creative-runtime-contract";
+import type { CreativeAsset, CreativeMessage } from "@/lib/creative-runtime-contract";
+import { cn } from "@/lib/utils";
 import type { CreativeAgentRun } from "@/services/api/creative";
 
 import { creativeRunMode } from "./creative-run-presentation";
 
 const LONG_WAIT_MESSAGES = ["主人，久等了，辛苦你再陪我一会儿，我一直在这里守着这次创作。", "主人，别担心，创作还在继续，不用重复发送，先放松一下，这里交给我守着吧。", "主人，作品正在慢慢雕琢，可能比平时久一点，但我没有离开。"] as const;
 
-export function CreativeGenerationWaiting({ run, message }: { run?: CreativeAgentRun; message: Pick<CreativeMessage, "content" | "createdAt"> }) {
+export function CreativeGenerationWaiting({ run, message, readyAssets = [] }: { run?: CreativeAgentRun; message: Pick<CreativeMessage, "content" | "createdAt">; readyAssets?: Array<Pick<CreativeAsset, "status" | "type">> }) {
     const startedAt = run?.createdAt || message.createdAt;
     const [now, setNow] = useState(() => Date.now());
 
@@ -23,9 +24,11 @@ export function CreativeGenerationWaiting({ run, message }: { run?: CreativeAgen
 
     const elapsedSeconds = Math.max(0, Math.floor((now - startedAt) / 1000));
     const copy = creativeGenerationWaitingCopy({ mode: creativeRunMode(run), runStatus: run?.status, progressText: message.content, elapsedSeconds });
+    const loadingSlots = creativeMediaLoadingSlots(run, readyAssets);
 
     return (
-        <div data-testid="creative-generation-waiting" className="mb-3 max-w-[520px] py-1 text-[#667085] dark:text-[#a0a9b4]">
+        <div data-testid="creative-generation-waiting" className="mb-3 max-w-[620px] py-1 text-[#667085] dark:text-[#a0a9b4]">
+            {loadingSlots.length ? <CreativeMediaLoadingGrid slots={loadingSlots} /> : null}
             <div className="flex items-start gap-2.5">
                 <Sparkles className="mt-1 size-4 shrink-0 animate-pulse text-primary/75" aria-hidden />
                 <div className="min-w-0">
@@ -39,6 +42,77 @@ export function CreativeGenerationWaiting({ run, message }: { run?: CreativeAgen
             </div>
         </div>
     );
+}
+
+type CreativeMediaLoadingSlot = { key: string; type: "image" | "video"; title: string; model?: string; ratio?: string };
+
+export function creativeMediaLoadingSlots(run: CreativeAgentRun | undefined, readyAssets: Array<Pick<CreativeAsset, "status" | "type">> = []): CreativeMediaLoadingSlot[] {
+    const ready = { image: readyAssets.filter((asset) => asset.type === "image" && asset.status === "ready").length, video: readyAssets.filter((asset) => asset.type === "video" && asset.status === "ready").length };
+    const tasks = (run?.tasks || []).filter((task) => (task.type === "image" || task.type === "video") && task.status !== "failed" && task.status !== "cancelled");
+    if (!tasks.length) {
+        const mode = creativeRunMode(run);
+        if (mode !== "image" && mode !== "video") return [];
+        const preferences = run?.generationPreferences?.[mode];
+        const count = Math.max(0, Math.floor(preferences?.count || 1) - ready[mode]);
+        return Array.from({ length: count }, (_, index) => ({ key: `${run?.id || mode}-${index}`, type: mode, title: mode === "video" ? "视频生成" : "图片生成", ratio: preferences?.size }));
+    }
+    return tasks.flatMap((task) => {
+        const type = task.type as "image" | "video";
+        const count = Math.max(1, Math.floor(task.count || 1));
+        const completed = Math.min(count, ready[type]);
+        ready[type] -= completed;
+        return Array.from({ length: count - completed }, (_, index) => ({ key: `${task.id}-${completed + index}`, type, title: task.title, model: task.model, ratio: task.ratio }));
+    });
+}
+
+function CreativeMediaLoadingGrid({ slots }: { slots: CreativeMediaLoadingSlot[] }) {
+    return (
+        <div data-testid="creative-media-loading-grid" data-slot-count={slots.length} className="mb-3 grid w-full grid-cols-1 gap-2.5 min-[560px]:grid-cols-2">
+            {slots.map((slot, index) => (
+                <CreativeMediaLoadingCard key={slot.key} slot={slot} index={index} />
+            ))}
+        </div>
+    );
+}
+
+function CreativeMediaLoadingCard({ slot, index }: { slot: CreativeMediaLoadingSlot; index: number }) {
+    return (
+        <div
+            data-testid="creative-media-loading"
+            data-loading-type={slot.type}
+            style={{ aspectRatio: loadingAspectRatio(slot.ratio, slot.type) }}
+            className="relative isolate min-h-40 w-full min-w-0 overflow-hidden rounded-xl border border-[#e5e7eb] bg-white shadow-[0_4px_18px_rgba(15,23,42,0.04)] dark:border-[#343a43] dark:bg-[#171a1f]"
+            role="status"
+            aria-label={`${slot.title}生成中 ${index + 1}`}
+        >
+            <span
+                className="absolute inset-0 bg-[radial-gradient(circle_at_32%_42%,rgba(255,142,199,.42),transparent_32%),radial-gradient(circle_at_68%_38%,rgba(152,116,255,.32),transparent_34%),radial-gradient(circle_at_50%_68%,rgba(95,218,238,.24),transparent_38%)] opacity-80 blur-2xl motion-safe:animate-pulse"
+                aria-hidden
+            />
+            <span className="absolute left-[24%] top-[22%] size-9 rounded-tl-[18px] border-l-[5px] border-t-[5px] border-white/95 drop-shadow-[0_1px_5px_rgba(255,255,255,.75)]" aria-hidden />
+            <span className="absolute right-[24%] top-[22%] size-9 rounded-tr-[18px] border-r-[5px] border-t-[5px] border-white/95 drop-shadow-[0_1px_5px_rgba(255,255,255,.75)]" aria-hidden />
+            <span className="absolute bottom-[22%] left-[24%] size-9 rounded-bl-[18px] border-b-[5px] border-l-[5px] border-white/95 drop-shadow-[0_1px_5px_rgba(255,255,255,.75)]" aria-hidden />
+            <span className="absolute bottom-[22%] right-[24%] size-9 rounded-br-[18px] border-b-[5px] border-r-[5px] border-white/95 drop-shadow-[0_1px_5px_rgba(255,255,255,.75)]" aria-hidden />
+            <span className="absolute inset-0 grid place-items-center" aria-hidden>
+                <span className="relative block size-16 motion-safe:animate-pulse">
+                    <svg viewBox="0 0 64 64" className="size-full overflow-visible drop-shadow-[0_6px_14px_rgba(129,92,246,.35)]">
+                        <path d="M31.5 4 38 22.8 57 29.5 38 36.2 31.5 55 25 36.2 6 29.5 25 22.8Z" fill="#8b5cf6" />
+                        <path d="M50 8.5 53 16l7.5 3-7.5 3-3 7.5-3-7.5-7.5-3 7.5-3Z" fill="#d946ef" className="origin-center motion-safe:animate-spin" />
+                        <path d="M49 37.5 51 42l4.5 2-4.5 2-2 4.5-2-4.5-4.5-2 4.5-2Z" fill="#fb7185" />
+                    </svg>
+                </span>
+            </span>
+            <span className={cn("absolute inset-x-3 bottom-2 truncate text-center text-[10px] font-medium text-[#7c8591] dark:text-[#a7b0ba]", !slot.model && "sr-only")}>{slot.model || slot.title}</span>
+        </div>
+    );
+}
+
+function loadingAspectRatio(value: string | undefined, type: "image" | "video") {
+    const match = value?.trim().match(/^(\d+(?:\.\d+)?)\s*[:x×]\s*(\d+(?:\.\d+)?)$/i);
+    if (!match) return type === "video" ? "16 / 9" : "1 / 1";
+    const width = Number(match[1]);
+    const height = Number(match[2]);
+    return width > 0 && height > 0 ? `${width} / ${height}` : type === "video" ? "16 / 9" : "1 / 1";
 }
 
 export function creativeGenerationWaitingCopy({ mode, runStatus, progressText, elapsedSeconds }: { mode?: "text" | "image" | "video" | "audio"; runStatus?: CreativeAgentRun["status"]; progressText: string; elapsedSeconds: number }) {

--- a/web/src/app/(user)/create/components/creative-generation-waiting.tsx
+++ b/web/src/app/(user)/create/components/creative-generation-waiting.tsx
@@ -48,8 +48,9 @@ type CreativeMediaLoadingSlot = { key: string; type: "planning" | "image" | "vid
 
 export function creativeMediaLoadingSlots(run: CreativeAgentRun | undefined, readyAssets: Array<Pick<CreativeAsset, "status" | "type">> = []): CreativeMediaLoadingSlot[] {
     const ready = { image: readyAssets.filter((asset) => asset.type === "image" && asset.status === "ready").length, video: readyAssets.filter((asset) => asset.type === "video" && asset.status === "ready").length };
-    const tasks = (run?.tasks || []).filter((task) => (task.type === "image" || task.type === "video") && task.status !== "failed" && task.status !== "cancelled");
+    const tasks = (run?.tasks || []).filter((task) => (task.type === "image" || task.type === "video") && (task.status === "ready" || task.status === "running"));
     if (!tasks.length) {
+        if (run && run.status !== "planning" && run.status !== "running") return [];
         const mode = creativeRunMode(run);
         if (mode !== "image" && mode !== "video") {
             return !run || (run.status === "planning" && !run.tasks.length) ? [{ key: `${run?.id || "pending"}-planning`, type: "planning", title: "正在规划创作" }] : [];

--- a/web/src/app/(user)/create/components/creative-generation-waiting.tsx
+++ b/web/src/app/(user)/create/components/creative-generation-waiting.tsx
@@ -44,14 +44,16 @@ export function CreativeGenerationWaiting({ run, message, readyAssets = [] }: { 
     );
 }
 
-type CreativeMediaLoadingSlot = { key: string; type: "image" | "video"; title: string; model?: string; ratio?: string };
+type CreativeMediaLoadingSlot = { key: string; type: "planning" | "image" | "video"; title: string; model?: string; ratio?: string };
 
 export function creativeMediaLoadingSlots(run: CreativeAgentRun | undefined, readyAssets: Array<Pick<CreativeAsset, "status" | "type">> = []): CreativeMediaLoadingSlot[] {
     const ready = { image: readyAssets.filter((asset) => asset.type === "image" && asset.status === "ready").length, video: readyAssets.filter((asset) => asset.type === "video" && asset.status === "ready").length };
     const tasks = (run?.tasks || []).filter((task) => (task.type === "image" || task.type === "video") && task.status !== "failed" && task.status !== "cancelled");
     if (!tasks.length) {
         const mode = creativeRunMode(run);
-        if (mode !== "image" && mode !== "video") return [];
+        if (mode !== "image" && mode !== "video") {
+            return !run || (run.status === "planning" && !run.tasks.length) ? [{ key: `${run?.id || "pending"}-planning`, type: "planning", title: "正在规划创作" }] : [];
+        }
         const preferences = run?.generationPreferences?.[mode];
         const count = Math.max(0, Math.floor(preferences?.count || 1) - ready[mode]);
         return Array.from({ length: count }, (_, index) => ({ key: `${run?.id || mode}-${index}`, type: mode, title: mode === "video" ? "视频生成" : "图片生成", ratio: preferences?.size }));
@@ -107,7 +109,7 @@ function CreativeMediaLoadingCard({ slot, index }: { slot: CreativeMediaLoadingS
     );
 }
 
-function loadingAspectRatio(value: string | undefined, type: "image" | "video") {
+function loadingAspectRatio(value: string | undefined, type: CreativeMediaLoadingSlot["type"]) {
     const match = value?.trim().match(/^(\d+(?:\.\d+)?)\s*[:x×]\s*(\d+(?:\.\d+)?)$/i);
     if (!match) return type === "video" ? "16 / 9" : "1 / 1";
     const width = Number(match[1]);

--- a/web/src/app/(user)/create/components/creative-messages.test.tsx
+++ b/web/src/app/(user)/create/components/creative-messages.test.tsx
@@ -475,7 +475,7 @@ describe("CreativeMessages", () => {
                             status: "running",
                             generationPreferences: { mode: "image", image: { size: "1:1", quality: "high" } },
                             assetIds: [],
-                            tasks: [{ id: "image-task", title: "图片生成", type: "image", status: "running" }],
+                            tasks: [{ id: "image-task", title: "图片生成", type: "image", model: "image-model", count: 2, status: "running" }],
                             createdAt: now,
                             updatedAt: now,
                         },
@@ -491,9 +491,15 @@ describe("CreativeMessages", () => {
         );
 
         expect(markup).toContain('data-testid="creative-generation-waiting"');
+        expect(markup).toContain('data-slot-count="2"');
+        expect(markup.match(/data-testid="creative-media-loading"/g)).toHaveLength(2);
         expect(markup).toContain("主人，画面正在一点点显现");
         expect(markup).toContain("已等待");
-        expect(markup).not.toContain("已为你生成图片");
+        expect(markup).toContain("正在生成图片");
+        expect(markup).toContain('aria-label="本轮创作参数"');
+        expect(markup).toContain("image-model");
+        expect(markup).toContain("1:1");
+        expect(markup).toContain("高画质");
         expect(markup).not.toContain("正在处理「图片生成」");
     });
 

--- a/web/src/app/(user)/create/components/creative-messages.test.tsx
+++ b/web/src/app/(user)/create/components/creative-messages.test.tsx
@@ -503,6 +503,80 @@ describe("CreativeMessages", () => {
         expect(markup).not.toContain("正在处理「图片生成」");
     });
 
+    it("shows the concrete review reason instead of a loading state for a paused media run", () => {
+        const userMessage: CreativeMessage = {
+            id: "paused-user",
+            conversationId: "conversation-one",
+            runId: "paused-run",
+            sequence: 1,
+            role: "user",
+            status: "completed",
+            content: "根据两张参考图生成视频",
+            metadata: {},
+            createdAt: 1,
+            updatedAt: 1,
+        };
+        const assistantMessage: CreativeMessage = {
+            id: "paused-assistant",
+            conversationId: "conversation-one",
+            runId: "paused-run",
+            sequence: 2,
+            role: "assistant",
+            status: "running",
+            content: "正在处理「视频生成」",
+            metadata: {},
+            createdAt: 1,
+            updatedAt: 1,
+        };
+        const markup = renderToStaticMarkup(
+            <App>
+                <CreativeMessages
+                    messages={[userMessage, assistantMessage]}
+                    assets={[]}
+                    loading={false}
+                    projectLinks={{}}
+                    projectErrors={{}}
+                    runDetails={{
+                        "paused-run": {
+                            id: "paused-run",
+                            conversationId: "conversation-one",
+                            inputMessageId: userMessage.id,
+                            assistantMessageId: assistantMessage.id,
+                            status: "paused",
+                            generationPreferences: { mode: "video" },
+                            assetIds: [],
+                            tasks: [
+                                {
+                                    id: "video-task",
+                                    title: "视频生成",
+                                    type: "video",
+                                    model: "video-model",
+                                    status: "needs_review",
+                                    error: "OpenAI 视频协议最多支持 1 张参考图",
+                                },
+                            ],
+                            createdAt: 1,
+                            updatedAt: 1,
+                        },
+                    }}
+                    onMaterializeProject={async () => {
+                        throw new Error("not used");
+                    }}
+                    onRetryMessage={vi.fn()}
+                    selectedAssetIds={[]}
+                    onToggleAsset={vi.fn()}
+                />
+            </App>,
+        );
+
+        expect(markup).toContain("任务已暂停");
+        expect(markup).toContain("OpenAI 视频协议最多支持 1 张参考图");
+        expect(markup).toContain('data-testid="creative-generation-review"');
+        expect(markup).not.toContain('data-testid="creative-generation-waiting"');
+        expect(markup).not.toContain("已等待");
+        expect(markup).not.toContain("直接重试");
+    });
+
     it("restores the original text before retrying an initial submission failure", () => {
         const userMessage: CreativeMessage = {
             id: "temporary-user",
@@ -649,7 +723,7 @@ describe("CreativeMessages", () => {
                             status: "failed",
                             generationPreferences: { mode: "video" },
                             assetIds: [],
-                            tasks: [],
+                            tasks: [{ id: "video-task", title: "视频生成", type: "video", model: "video-model", status: "failed", error: "视频请求参数无效：duration 只支持 5 或 10 秒" }],
                         },
                     }}
                     onMaterializeProject={async () => {
@@ -667,6 +741,8 @@ describe("CreativeMessages", () => {
         expect((markup.match(/data-testid="creative-assistant-avatar"/g) || []).length).toBe(1);
         expect(markup).toContain('aria-label="直接重试本次创作"');
         expect(markup).toContain("直接重试");
+        expect(markup).toContain("视频请求参数无效：duration 只支持 5 或 10 秒");
+        expect(markup).not.toContain("当前请求参数不被模型支持");
         const failureMarkup = markup.slice(markup.indexOf('data-testid="creative-generation-failure"'));
         expect(failureMarkup).not.toContain("size-12");
         expect(failureMarkup).not.toContain("Sparkles");

--- a/web/src/app/(user)/create/components/creative-messages.tsx
+++ b/web/src/app/(user)/create/components/creative-messages.tsx
@@ -232,6 +232,10 @@ function CreativeMediaRound({
     const displayContent = assistantMessage.status === "failed" ? friendlyAgentError(assistantMessage.content) : formatAgentMessageText(assistantMessage.content);
     const handoff = isCreativeProjectHandoff(assistantMessage.metadata.projectHandoff) ? assistantMessage.metadata.projectHandoff : null;
     const failedTasks = run?.tasks.filter((task) => task.status === "failed") || [];
+    const reviewTasks = run?.tasks.filter((task) => task.status === "needs_review") || [];
+    const isPausedMediaRound = run?.status === "paused";
+    const failureReason = Array.from(new Set(failedTasks.map((task) => task.error?.trim()).filter((value): value is string => Boolean(value)))).join("；") || displayContent;
+    const reviewReason = reviewTasks.map((task) => task.error?.trim()).find(Boolean) || "上游创建结果待确认；为避免重复生成和扣费，任务已暂停。";
     const mediaOutputs = outputAssets.filter((asset) => asset.type !== "text" && assetUrl(asset));
     const videoOutputs = mediaOutputs.filter((asset) => asset.type === "video");
     const otherMediaOutputs = mediaOutputs.filter((asset) => asset.type !== "video");
@@ -267,16 +271,20 @@ function CreativeMediaRound({
                             <>
                                 <div className="mb-2 flex w-fit max-w-full flex-wrap items-baseline gap-x-3 gap-y-0.5">
                                     <h2 className="truncate text-[17px] font-semibold leading-7 text-[#1f2937] dark:text-[#f3f5f7]">
-                                        {assistantMessage.status === "running" ? (mode === "video" ? "正在生成视频" : mode === "audio" ? "正在生成音频" : "正在生成图片") : resultTitle}
+                                        {isPausedMediaRound ? "任务已暂停" : assistantMessage.status === "running" ? (mode === "video" ? "正在生成视频" : mode === "audio" ? "正在生成音频" : "正在生成图片") : resultTitle}
                                     </h2>
-                                    {assistantMessage.status === "running" ? null : <CreativeRunTiming run={run} time={assistantMessage.createdAt} />}
+                                    {assistantMessage.status === "running" && !isPausedMediaRound ? null : <CreativeRunTiming run={run} time={assistantMessage.createdAt} />}
                                 </div>
                                 <CreativeRunSummary run={run} modelNames={modelNames} />
                             </>
                         ) : null}
                         <div data-testid="creative-result-group" className="mt-3 flex w-fit max-w-full flex-col items-start">
                             {isFailedMediaRound ? (
-                                <CreativeGenerationFailure message={failedTasks.length === 1 ? failedTasks[0]?.error || displayContent : displayContent} onRetry={() => onRetryMessage(assistantMessage, run)} />
+                                <CreativeGenerationFailure message={failureReason} onRetry={() => onRetryMessage(assistantMessage, run)} />
+                            ) : isPausedMediaRound ? (
+                                <p data-testid="creative-generation-review" className="max-w-[620px] break-words py-1 text-[15px] font-medium leading-7 text-amber-700 dark:text-amber-300">
+                                    {reviewReason}
+                                </p>
                             ) : assistantMessage.status === "running" ? (
                                 <CreativeGenerationWaiting run={run} message={assistantMessage} readyAssets={outputAssets} />
                             ) : showAssistantText ? (
@@ -568,12 +576,11 @@ function assetsForAssistant(message: CreativeMessage, assetsByMessage: Map<strin
 }
 
 function CreativeGenerationFailure({ message, onRetry }: { message: string; onRetry: () => Promise<boolean | void> }) {
-    const displayMessage = friendlyAgentError(message, "创作任务执行失败");
     const [retrying, setRetrying] = useState(false);
     return (
         <div data-testid="creative-generation-failure" className="max-w-[620px] py-1">
             <div className="min-w-0">
-                <p className="break-words text-[17px] font-medium leading-7 text-[#ef2b2d] dark:text-[#ff8b8d]">{displayMessage}</p>
+                <p className="break-words text-[17px] font-medium leading-7 text-[#ef2b2d] dark:text-[#ff8b8d]">{message || "创作任务执行失败"}</p>
                 <Button
                     type="default"
                     className="!mt-3 !h-9 !rounded-[10px] !border-[#ffd4d5] !bg-white !px-4 !text-sm !font-medium !text-[#e22b2e] hover:!border-[#ffb7b8] hover:!bg-[#fff8f8] hover:!text-[#c51f22] dark:!border-[#6b3438] dark:!bg-transparent dark:!text-[#ff9a9c] dark:hover:!border-[#9a4a4e] dark:hover:!bg-[#321e20]"

--- a/web/src/app/(user)/create/components/creative-messages.tsx
+++ b/web/src/app/(user)/create/components/creative-messages.tsx
@@ -263,11 +263,13 @@ function CreativeMediaRound({
                 <div className="flex min-w-0 items-start gap-4 sm:gap-5">
                     <CreativeAssistantAvatar logoUrl={siteLogoUrl} />
                     <div className="min-w-0 flex-1">
-                        {!isFailedMediaRound && assistantMessage.status !== "running" ? (
+                        {!isFailedMediaRound ? (
                             <>
                                 <div className="mb-2 flex w-fit max-w-full flex-wrap items-baseline gap-x-3 gap-y-0.5">
-                                    <h2 className="truncate text-[17px] font-semibold leading-7 text-[#1f2937] dark:text-[#f3f5f7]">{resultTitle}</h2>
-                                    <CreativeRunTiming run={run} time={assistantMessage.createdAt} />
+                                    <h2 className="truncate text-[17px] font-semibold leading-7 text-[#1f2937] dark:text-[#f3f5f7]">
+                                        {assistantMessage.status === "running" ? (mode === "video" ? "正在生成视频" : mode === "audio" ? "正在生成音频" : "正在生成图片") : resultTitle}
+                                    </h2>
+                                    {assistantMessage.status === "running" ? null : <CreativeRunTiming run={run} time={assistantMessage.createdAt} />}
                                 </div>
                                 <CreativeRunSummary run={run} modelNames={modelNames} />
                             </>
@@ -276,7 +278,7 @@ function CreativeMediaRound({
                             {isFailedMediaRound ? (
                                 <CreativeGenerationFailure message={failedTasks.length === 1 ? failedTasks[0]?.error || displayContent : displayContent} onRetry={() => onRetryMessage(assistantMessage, run)} />
                             ) : assistantMessage.status === "running" ? (
-                                <CreativeGenerationWaiting run={run} message={assistantMessage} />
+                                <CreativeGenerationWaiting run={run} message={assistantMessage} readyAssets={outputAssets} />
                             ) : showAssistantText ? (
                                 <div
                                     className={cn(

--- a/web/src/app/(user)/create/components/creative-run-presentation.test.ts
+++ b/web/src/app/(user)/create/components/creative-run-presentation.test.ts
@@ -49,6 +49,32 @@ describe("creativeRunPresentation", () => {
         ]);
     });
 
+    it("keeps every media model and output count for mixed concurrent generation", () => {
+        const run = {
+            id: "run-mixed",
+            conversationId: "conversation-one",
+            inputMessageId: "user-mixed",
+            assistantMessageId: "assistant-mixed",
+            status: "running",
+            assetIds: [],
+            tasks: [
+                { id: "images", title: "生成图片", type: "image", model: "image-model", count: 2, status: "running" },
+                { id: "videos", title: "生成视频", type: "video", model: "video-model", count: 2, status: "running" },
+            ],
+        } satisfies CreativeAgentRun;
+
+        const items = creativeRunPresentation(
+            run,
+            new Map([
+                ["image-model", "图片模型"],
+                ["video-model", "视频模型"],
+            ]),
+        );
+
+        expect(items).toContainEqual({ key: "model", label: "模型", value: "图片模型 + 视频模型" });
+        expect(items).toContainEqual({ key: "count", label: "数量", value: "4个结果" });
+    });
+
     it("formats the persisted run duration without inventing a timeout", () => {
         expect(creativeRunDuration({ createdAt: 1_000, updatedAt: 66_000 } as CreativeAgentRun)).toBe("1分5秒");
         expect(creativeRunDuration({ createdAt: 1_000, updatedAt: 1_200 } as CreativeAgentRun)).toBe("1秒");

--- a/web/src/app/(user)/create/components/creative-run-presentation.ts
+++ b/web/src/app/(user)/create/components/creative-run-presentation.ts
@@ -6,12 +6,13 @@ export type CreativeRunPresentationItem = { key: string; label: string; value: s
 export function creativeRunPresentation(run: CreativeAgentRun | undefined, modelNames: ReadonlyMap<string, string>) {
     if (!run) return [];
     const mode = creativeRunMode(run);
-    const tasks = mode ? run.tasks.filter((task) => task.type === mode) : run.tasks;
+    const mediaTasks = run.tasks.filter((task) => task.type === "image" || task.type === "video" || task.type === "audio");
+    const tasks = mode ? mediaTasks.filter((task) => task.type === mode) : run.tasks;
     const preferences = mode ? run.generationPreferences?.[mode] : undefined;
     const items: CreativeRunPresentationItem[] = [];
     if (mode) items.push({ key: "mode", label: "类型", value: mediaModeLabel(mode) });
 
-    const modelIds = uniqueText([...tasks.map((task) => task.model), ...(run.requestedModelIds || [])]);
+    const modelIds = uniqueText([...mediaTasks.map((task) => task.model), ...(run.requestedModelIds || [])]);
     if (modelIds.length) items.push({ key: "model", label: "模型", value: modelIds.map((id) => modelNames.get(id) || id).join(" + ") });
 
     const size = firstText(tasks.map((task) => task.ratio)) || (preferences && "size" in preferences ? preferences.size : undefined);
@@ -28,7 +29,7 @@ export function creativeRunPresentation(run: CreativeAgentRun | undefined, model
     const format = firstText(tasks.map((task) => task.format)) || (preferences && "format" in preferences ? preferences.format : undefined);
     if (format) items.push({ key: "format", label: "格式", value: format.toUpperCase() });
 
-    const count = tasks.reduce((total, task) => total + (task.count || 1), 0);
+    const count = mediaTasks.reduce((total, task) => total + (task.count || 1), 0);
     if (count > 1) items.push({ key: "count", label: "数量", value: `${count}个结果` });
     items.push({ key: "status", label: "状态", value: runStatusLabel(run.status) });
     return items;

--- a/web/src/app/(user)/create/page.tsx
+++ b/web/src/app/(user)/create/page.tsx
@@ -8,7 +8,7 @@ import { useRouter } from "next/navigation";
 
 import { CREATIVE_UPLOAD_ACCEPT, CREATIVE_UPLOAD_MAX_BYTES, isCreativeUploadMimeType } from "@/lib/creative-upload";
 import type { CreateOverviewAsset } from "@/lib/create-workbench-overview";
-import type { CreativeAsset, CreativeGenerationMode, CreativeGenerationPreferences, CreativeMessage } from "@/lib/creative-runtime-contract";
+import { agentSkillSupportsGenerationMode, type CreativeAsset, type CreativeGenerationMode, type CreativeGenerationPreferences, type CreativeMessage } from "@/lib/creative-runtime-contract";
 import { reconcileCreativeGenerationPreferences } from "@/lib/creative-model-capabilities";
 import { cn } from "@/lib/utils";
 import type { VideoReferenceRole } from "@/lib/video-reference-contract";
@@ -23,7 +23,7 @@ import { resolveSiteTitle } from "@/lib/site-brand";
 
 import { CreativeComposer } from "./components/creative-composer";
 import { CreativeAssetsPanel } from "./components/creative-assets-panel";
-import { applyAgentGenerationCapability, shouldShowVideoFrameControls } from "./components/creative-composer-video-mode";
+import { applyAgentGenerationCapability, generationPreferencesAfterSubmit, generationPreferencesForSelectedSkill, shouldShowVideoFrameControls } from "./components/creative-composer-video-mode";
 import { CreativeConversationList } from "./components/creative-conversation-list";
 import { CreateInspirationGallery } from "./components/create-inspiration-gallery";
 import { CreativeMessages } from "./components/creative-messages";
@@ -219,7 +219,7 @@ export default function CreatePage() {
             ) {
                 updatePrompt("");
                 setSelectedSkillId(undefined);
-                setGenerationPreferences((current) => (current.video ? { ...current, video: { ...current.video, firstFrameAssetId: undefined, lastFrameAssetId: undefined } } : current));
+                setGenerationPreferences((current) => generationPreferencesAfterSubmit(creationMode, current));
             }
         } catch (error) {
             message.error(error instanceof Error ? error.message : "素材上传失败");
@@ -321,7 +321,12 @@ export default function CreatePage() {
     };
 
     const selectSkill = (skill: AgentSkillSummary) => {
+        if (creationMode !== "agent" && !agentSkillSupportsGenerationMode(skill.workspaces, creationMode)) {
+            message.warning(`${skill.name}不支持${creationMode === "video" ? "视频" : creationMode === "image" ? "图片" : "音频"}生成，请先切换创作类型`);
+            return;
+        }
         setSelectedSkillId(skill.id);
+        setGenerationPreferences((current) => generationPreferencesForSelectedSkill(current, skill.workspaces));
         window.requestAnimationFrame(() => inputRef.current?.focus());
     };
 

--- a/web/src/app/api/agent/runs/route.test.ts
+++ b/web/src/app/api/agent/runs/route.test.ts
@@ -28,7 +28,7 @@ describe("POST /api/agent/runs", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mocks.getCurrentUser.mockResolvedValue({ id: "user" });
-        mocks.getAuthSettings.mockResolvedValue({ generationConcurrency: { agent: 2 } });
+        mocks.getAuthSettings.mockResolvedValue({ generationConcurrency: { agent: 2 }, agentSkills: [] });
         mocks.checkRateLimit.mockReturnValue({ allowed: true });
         mocks.countActiveStoredGenerationTasks.mockResolvedValue(0);
         mocks.withGenerationConcurrencyLimit.mockImplementation(async (_userId, _type, _staleMs, _limit, handler) => handler());
@@ -75,6 +75,19 @@ describe("POST /api/agent/runs", () => {
             snapshot: undefined,
         });
         expect(mocks.after).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it("rejects an incompatible selected Skill before creating or charging a run", async () => {
+        mocks.getAuthSettings.mockResolvedValue({
+            generationConcurrency: { agent: 2 },
+            agentSkills: [{ id: "ecommerce-image", name: "电商生图", enabled: true, workspaces: ["image", "canvas"] }],
+        });
+        const response = await POST(request({ ...validInput(), skillIds: ["ecommerce-image"], preferences: { mode: "video" } }));
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toMatchObject({ msg: "电商生图仅支持图片生成，请切换创作类型或取消该 Skill" });
+        expect(mocks.withGenerationConcurrencyLimit).not.toHaveBeenCalled();
+        expect(mocks.createAgentRun).not.toHaveBeenCalled();
     });
 });
 

--- a/web/src/app/api/agent/runs/route.ts
+++ b/web/src/app/api/agent/runs/route.ts
@@ -10,6 +10,7 @@ import { CreativeStoreConflict } from "@/lib/server/creative-runtime-store";
 import { resolveInternalOrigin } from "@/lib/server/internal-origin";
 import { runGenerationTaskRecoveryBatch } from "@/lib/server/generation-task-recovery-service";
 import { publicAgentRun } from "@/lib/server/agent-run-public";
+import { assertAgentSkillModeCompatibility } from "@/lib/server/agent-run-surface-policy";
 
 export const maxDuration = 2400;
 
@@ -46,6 +47,7 @@ export async function POST(request: Request) {
         const rate = await checkRateLimit(`agent-run:${user.id}`, { maxRequests: 10, windowMs: 60 * 1000 });
         if (!rate.allowed) return NextResponse.json({ code: 429, data: null, msg: "Agent 请求过于频繁，请稍后重试" }, { status: 429 });
         const settings = await getAuthSettings();
+        assertAgentSkillModeCompatibility(settings, input);
         const response = await withGenerationConcurrencyLimit(
             user.id,
             "agent",

--- a/web/src/lib/creative-runtime-contract.ts
+++ b/web/src/lib/creative-runtime-contract.ts
@@ -137,6 +137,12 @@ export type CreativeGenerationPreferences = {
     audio?: { voice?: string; format?: string; speed?: number };
 };
 
+export function agentSkillSupportsGenerationMode(workspaces: readonly string[] | undefined, mode: CreativeGenerationMode) {
+    if (mode === "audio") return true;
+    const supported = (workspaces || ["image"]).filter((workspace) => workspace === "image" || workspace === "video");
+    return supported.length === 0 || supported.includes(mode);
+}
+
 export type CreativeRunRequest = {
     clientRequestId: string;
     surface: CreativeSurface;

--- a/web/src/lib/server/agent-run-execution.ts
+++ b/web/src/lib/server/agent-run-execution.ts
@@ -868,13 +868,13 @@ export async function pollTask(origin: string, path: string, taskId: string, coo
         if ([408, 425, 429].includes(response.status) || response.status >= 500) throw new AgentChildTaskDeferredError("生成任务查询暂时不可用");
         throw new AgentChildTaskTerminalError((await response.text()) || "生成任务查询失败");
     }
-    let payload: { task?: { status?: string; result?: unknown; error?: string; needsReview?: boolean } };
+    let payload: { task?: { status?: string; result?: unknown; error?: string; needsReview?: boolean; reviewReason?: string } };
     try {
         payload = (await response.json()) as typeof payload;
     } catch {
         throw new AgentChildTaskDeferredError("生成任务状态暂时无法解析");
     }
-    if (payload.task?.needsReview) throw new AgentChildTaskDeferredError("上游创建状态待确认", true);
+    if (payload.task?.needsReview) throw new AgentChildTaskDeferredError(payload.task.reviewReason?.trim() || payload.task.error?.trim() || "上游创建状态待确认", true);
     const terminal = agentChildTaskTerminal(payload.task?.status);
     if (terminal === "success") return payload.task?.result;
     if (terminal === "error") throw new AgentChildTaskTerminalError(payload.task?.error || "生成任务失败");

--- a/web/src/lib/server/agent-run-executor.test.ts
+++ b/web/src/lib/server/agent-run-executor.test.ts
@@ -419,7 +419,9 @@ describe("executeAgentRun backend settings", () => {
             if (init?.method === "POST" && url.endsWith("/api/image-tasks")) return Response.json({ task: { id: "child-review" } });
             if (url.endsWith("/api/image-tasks/child-review")) {
                 polls += 1;
-                return polls === 1 ? Response.json({ task: { status: "running", needsReview: true, reviewReason: "上游创建状态待确认" } }) : Response.json({ task: { status: "success", result: { url: "https://cdn.example.com/recovered.png" } } });
+                return polls === 1
+                    ? Response.json({ task: { status: "running", needsReview: true, reviewReason: "图片上游接口 /v1/images/edits 返回 HTTP 502" } })
+                    : Response.json({ task: { status: "success", result: { url: "https://cdn.example.com/recovered.png" } } });
             }
             throw new Error(`unexpected request: ${url}`);
         });
@@ -429,7 +431,14 @@ describe("executeAgentRun backend settings", () => {
         expect(mocks.fetchInternalApi.mock.calls.filter((call) => call[1]?.method === "POST")).toHaveLength(1);
         expect(mocks.run).toMatchObject({
             status: "paused",
-            tasks: [expect.objectContaining({ status: "needs_review", taskId: "child-review", childTasks: [expect.objectContaining({ id: "child-review", status: "needs_review" })] })],
+            tasks: [
+                expect.objectContaining({
+                    status: "needs_review",
+                    error: "图片上游接口 /v1/images/edits 返回 HTTP 502",
+                    taskId: "child-review",
+                    childTasks: [expect.objectContaining({ id: "child-review", status: "needs_review", error: "图片上游接口 /v1/images/edits 返回 HTTP 502" })],
+                }),
+            ],
         });
         expect(mocks.events.some((event) => event.type === "task.needs_review")).toBe(true);
         expect(mocks.events.some((event) => event.type === "run.paused")).toBe(true);

--- a/web/src/lib/server/agent-run-surface-policy.ts
+++ b/web/src/lib/server/agent-run-surface-policy.ts
@@ -1,5 +1,5 @@
 import type { AuthSettings } from "@/lib/auth/store";
-import type { CreativeAsset, CreativeConversationContext, CreativeSurface } from "@/lib/creative-runtime-contract";
+import { agentSkillSupportsGenerationMode, CreativeRuntimeInputError, type CreativeAsset, type CreativeConversationContext, type CreativeRunRequest, type CreativeSurface } from "@/lib/creative-runtime-contract";
 import { creativeAssetReferenceAliases, orderCreativeAssetsByIds } from "@/lib/creative-asset-references";
 import { resolveSiteTitle } from "@/lib/site-brand";
 import type { AgentRun, AgentRunPlannerContextSummary, AgentRunTask } from "@/lib/server/agent-run-store";
@@ -16,6 +16,15 @@ export function availableAgentSkills(settings: AuthSettings, surface: CreativeSu
 export function selectAgentSkills(settings: AuthSettings, surface: CreativeSurface, requestedSkillIds: string[] = []) {
     const available = new Map(availableAgentSkills(settings, surface).map((skill) => [skill.id, skill]));
     return Array.from(new Set(requestedSkillIds.map((id) => id.trim()).filter(Boolean))).flatMap((id) => (available.has(id) ? [available.get(id)!] : []));
+}
+
+export function assertAgentSkillModeCompatibility(settings: AuthSettings, input: Pick<CreativeRunRequest, "surface" | "skillIds" | "preferences">) {
+    const mode = input.preferences?.mode;
+    if (!mode) return;
+    const incompatible = selectAgentSkills(settings, input.surface, input.skillIds).find((skill) => !agentSkillSupportsGenerationMode(skill.workspaces, mode));
+    if (!incompatible) return;
+    const supported = (incompatible.workspaces || ["image"]).filter((workspace) => workspace === "image" || workspace === "video").map((workspace) => (workspace === "image" ? "图片" : "视频"));
+    throw new CreativeRuntimeInputError(`${incompatible.name}仅支持${supported.join("、")}生成，请切换创作类型或取消该 Skill`);
 }
 
 export function plannerAgentSkills(settings: AuthSettings, run: Pick<AgentRun, "surface" | "selectedSkillIds">) {

--- a/web/src/lib/server/video-task-runtime.test.ts
+++ b/web/src/lib/server/video-task-runtime.test.ts
@@ -62,6 +62,22 @@ describe("video task upstream reconciliation", () => {
         expect(headers.has("cookie")).toBe(false);
     });
 
+    it("treats a provider business error in the configured result field as failure", async () => {
+        const task = videoTask({
+            config: {
+                ...videoTask().config,
+                advancedConfig: { ...videoTask().config.advancedConfig, resultField: "content" } as NonNullable<VideoTask["config"]["advancedConfig"]>,
+            },
+        });
+        mocks.fetchInternalApi.mockResolvedValue(json({ status: "completed", content: "TokenPony business error 0:" }));
+
+        await expect(queryVideoTaskUpstream(task, "http://localhost", "session=test")).resolves.toEqual({
+            state: "failed",
+            status: "completed",
+            error: "TokenPony business error 0:",
+        });
+    });
+
     it("recovers a locally timed-out task after the provider later returns a video", async () => {
         const task = videoTask({ status: "error", error: "视频任务长时间未更新，请重新查询或生成。" });
         const completed = { ...task, status: "success", result: { url: "/api/reference-assets/result.mp4", mimeType: "video/mp4", durationMs: 5_000 } };

--- a/web/src/lib/server/video-task-runtime.ts
+++ b/web/src/lib/server/video-task-runtime.ts
@@ -34,10 +34,11 @@ export async function queryVideoTaskUpstream(task: VideoTask, origin: string, co
     const data = await queryVideoUpstream(task, origin, cookie, workerUserId);
     const status = readVideoProviderStatus(data, task.config.advancedConfig?.statusField);
     const resultUrl = readVideoProviderUrl(data, task.config.advancedConfig?.resultField);
+    const resultError = !/^(?:https?:\/\/|data:video\/|\/)/i.test(resultUrl) && /(?:business\s+error|\berror\b|\bfailed\b|失败|错误|异常)/i.test(resultUrl) ? resultUrl : "";
+    if (resultError || isProviderBusinessError(data) || VIDEO_PROVIDER_FAILED.has(status)) return { state: "failed", status: status || "failed", error: readProviderError(data) || resultError || "视频生成失败" };
     if (resultUrl || VIDEO_PROVIDER_SUCCESS.has(status)) {
         return resultUrl ? { state: "result_ready", status: status || "completed", resultUrl } : { state: "failed", status: status || "completed", error: "视频任务已完成但没有返回视频地址" };
     }
-    if (isProviderBusinessError(data) || VIDEO_PROVIDER_FAILED.has(status)) return { state: "failed", status: status || "failed", error: readProviderError(data) || "视频生成失败" };
     return { state: "pending", status: status || "processing" };
 }
 


### PR DESCRIPTION
## 背景

统一创作 Agent 在切换 Skill 或完成一轮提交后，可能残留上一轮图片/视频生成偏好，导致图片 Skill 被错误地按视频模式执行；部分视频上游还会把业务错误文本放在结果字段中，旧逻辑会把它当作媒体地址重复下载。同时，图片和视频生成期间缺少按真实任务数量展示的明确等待状态，Agent 仍处于规划阶段时还会先出现一段只有文字、没有加载动画的空档。任务进入 needs_review 后，页面过去仍可能继续展示加载状态和泛化错误，容易诱导重复提交。

## 改动

- 提交后清理旧的 generationPreferences，选择 Skill 时清理与其能力冲突的图片/视频模式及首尾帧状态。
- 在规划、并发占用和计费前校验 Skill 与显式生成模式；不兼容请求直接返回 400。
- 视频结果字段中的 TokenPony 等业务错误文本优先按失败处理，不再持久化为媒体 URL。
- 请求尚未返回 Run，或 Run 仍在 planning 且尚无媒体任务时，立即显示一个通用创作加载槽。
- 规划完成后按每个图片/视频任务的 count 展示独立等待槽位，真实结果就绪后逐个减少。
- Agent 子任务进入 needs_review 时透传任务接口已持久化的 reviewReason，不再改写成泛化提示。
- 暂停轮次显示“任务已暂停”和具体原因，停止加载动画、等待时长及误导性的直接重试。
- 失败轮次保留服务端已经脱敏的确定性错误，不再由前端二次泛化。

## 验证

- 在官方最新 main 基线上保持独立提交。
- 首轮专项 Vitest：6 个文件、49 项测试通过。
- 规划阶段补充回归：2 个文件、21 项测试通过。
- 本轮暂停态与错误透传专项：3 个文件、66 项测试通过。
- TypeScript 类型检查通过。
- Prettier 与 git diff --check 通过。
- 私有部署已完成健康和只读状态验收；未为 PR 触发任何付费生成。
