### PR TITLE
修复：统一视频参考素材协议、错误处理与 NewAPI 多素材

### DIFF
--- a/web/src/app/api/video-generation-tasks/route.test.ts
+++ b/web/src/app/api/video-generation-tasks/route.test.ts
@@ -243,7 +243,11 @@ describe("video generation candidate failover", () => {
         expect(response.status).toBe(202);
         expect(mocks.fetchInternalApi.mock.calls.some(([url]) => String(url).includes("/api/ai/system/two/"))).toBe(false);
         expect(mocks.createVideoTask).toHaveBeenCalledOnce();
-        expect(mocks.scheduleGenerationTask).toHaveBeenLastCalledWith("video", "local-task", expect.objectContaining({ executionPhase: "needs_review", nextPollAt: undefined, lastUpstreamStatus: "submission_outcome_unknown" }));
+        expect(mocks.scheduleGenerationTask).toHaveBeenLastCalledWith(
+            "video",
+            "local-task",
+            expect.objectContaining({ executionPhase: "needs_review", nextPollAt: undefined, lastUpstreamStatus: "submission_outcome_unknown", resultPayload: { reviewReason: expect.stringContaining("视频接口返回了无效 JSON") } }),
+        );
         expect(mocks.refundUserPoints).not.toHaveBeenCalled();
         expect(mocks.updateVideoTask).toHaveBeenCalledWith("local-task", expect.objectContaining({ upstream: expect.objectContaining({ pointsCost: 2.5, pointsUnits: expect.any(Number), pointsRecordId: "video-points-unknown", refunded: false }) }));
     });
@@ -267,6 +271,38 @@ describe("video generation candidate failover", () => {
         expect(response.status).toBe(502);
         expect((await response.json()).error).toBe("登录验证失败");
         expect(mocks.createVideoTask).toHaveBeenCalledOnce();
+    });
+
+    it("treats any local protocol request-construction error as a concrete safe failure", async () => {
+        mocks.getAuthSettings.mockResolvedValue({
+            ...settings,
+            systemChannels: [
+                {
+                    ...channels[0],
+                    advancedConfig: {
+                        protocol: "custom",
+                        modelConfigs: {
+                            "video-one": {
+                                capability: "video",
+                                protocol: "custom",
+                                createPath: "/videos",
+                                requestTemplate: "{invalid-json",
+                                resultField: "id",
+                            },
+                        },
+                    },
+                },
+            ],
+            logicalModels: [{ ...settings.logicalModels[0], bindings: [settings.logicalModels[0].bindings[0]] }],
+        });
+
+        const response = await POST(request());
+
+        expect(response.status).toBe(502);
+        expect(await response.json()).toMatchObject({ error: "高级请求模板必须是有效 JSON", canRetry: true });
+        expect(mocks.fetchInternalApi).not.toHaveBeenCalled();
+        expect(mocks.scheduleGenerationTask.mock.calls.some(([, , patch]) => patch.executionPhase === "needs_review")).toBe(false);
+        expect(mocks.transitionVideoTask).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ status: "error", error: "高级请求模板必须是有效 JSON", retryable: true }));
     });
 
     it("enqueues a GlobalAiOpc task for the recovery worker after creation", async () => {
@@ -484,6 +520,17 @@ describe("video generation candidate failover", () => {
         expect(body.get("seconds")).toBe("5");
         expect(body.get("size")).toBe("1280x720");
         expect(body.get("input_reference")).toBeInstanceOf(File);
+
+        const excessiveResponse = await POST(
+            request({ model: "video", videoSeconds: "5", size: "16:9" }, [
+                { type: "image", url: reference },
+                { type: "image", url: `${reference}#second` },
+            ]),
+        );
+
+        expect(excessiveResponse.status).toBe(400);
+        expect((await excessiveResponse.json()).error).toBe("OpenAI 视频协议最多支持 1 张参考图");
+        expect(mocks.fetchInternalApi).toHaveBeenCalledTimes(1);
 
         mocks.fetchInternalApi.mockResolvedValue(json({ id: "upstream-openai-auto", status: "queued" }));
         const intelligentResponse = await POST(request({ model: "video", videoSeconds: "5", size: "auto", vquality: "auto" }));

--- a/web/src/app/api/video-generation-tasks/route.test.ts
+++ b/web/src/app/api/video-generation-tasks/route.test.ts
@@ -467,7 +467,7 @@ describe("video generation candidate failover", () => {
                     },
                 },
             ],
-            logicalModels: [{ ...settings.logicalModels[0], bindings: [settings.logicalModels[0].bindings[0]] }],
+            logicalModels: [{ ...settings.logicalModels[0], bindings: [{ ...settings.logicalModels[0].bindings[0], capabilityProfile: { supportsReferenceVideo: true } }] }],
         });
         mocks.fetchInternalApi.mockResolvedValue(json({ id: "upstream-openai", status: "queued" }));
         const reference = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
@@ -491,6 +491,27 @@ describe("video generation candidate failover", () => {
 
         expect(intelligentResponse.status).toBe(200);
         expect(intelligentBody.get("size")).toBeNull();
+
+        mocks.fetchInternalApi.mockResolvedValue(json({ id: "upstream-openai-reference-video", status: "queued" }));
+        const videoResponse = await POST(request({ model: "video", videoSeconds: "5", size: "16:9" }, [{ type: "video", url: "https://cdn.example.com/reference.mp4" }]));
+        const videoInit = (mocks.fetchInternalApi.mock.calls[2] as [string, RequestInit])[1];
+        const videoBody = JSON.parse(String(videoInit.body));
+
+        expect(videoResponse.status).toBe(200);
+        expect(new Headers(videoInit.headers).get("content-type")).toBe("application/json");
+        expect(videoBody).toEqual({
+            model: "video-one",
+            prompt: expect.stringContaining("A test video"),
+            duration: 5,
+            resolution: "720p",
+            ratio: "16:9",
+            content: [
+                { type: "text", text: expect.stringContaining("A test video") },
+                { type: "video_url", role: "reference_video", video_url: { url: "https://cdn.example.com/reference.mp4" } },
+            ],
+            generate_audio: true,
+            watermark: false,
+        });
     });
 
     it("persists the Drama project, episode and shot task context", async () => {

--- a/web/src/app/api/video-generation-tasks/route.test.ts
+++ b/web/src/app/api/video-generation-tasks/route.test.ts
@@ -561,6 +561,63 @@ describe("video generation candidate failover", () => {
         });
     });
 
+    it("keeps New API single-image multipart and uses JSON content for advanced references", async () => {
+        mocks.getAuthSettings.mockResolvedValue(newApiSettings());
+        mocks.fetchInternalApi.mockImplementation(async () => json({ id: "upstream-newapi", status: "queued" }));
+        const inlineImage = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+        const singleResponse = await POST(request({ model: "video", videoSeconds: "5", size: "16:9" }, [{ type: "image", url: inlineImage }], { clientRequestId: "newapi-single" }));
+        const singleInit = (mocks.fetchInternalApi.mock.calls[0] as [string, RequestInit])[1];
+        expect(singleResponse.status).toBe(200);
+        expect(singleInit.body).toBeInstanceOf(FormData);
+        expect((singleInit.body as FormData).get("input_reference")).toBeInstanceOf(File);
+        expect(new Headers(singleInit.headers).has("content-type")).toBe(false);
+
+        const imageReferences = [
+            { type: "image", url: "https://cdn.example.com/product.png" },
+            { type: "image", url: "https://cdn.example.com/poster.png" },
+        ];
+        const multiResponse = await POST(request({ model: "video", videoSeconds: "5", size: "16:9" }, imageReferences, { clientRequestId: "newapi-multi" }));
+        const multiInit = (mocks.fetchInternalApi.mock.calls[1] as [string, RequestInit])[1];
+        const multiBody = JSON.parse(String(multiInit.body));
+        expect(multiResponse.status).toBe(200);
+        expect(new Headers(multiInit.headers).get("content-type")).toBe("application/json");
+        expect(multiBody.content).toEqual([
+            { type: "image_url", role: "reference_image", image_url: { url: imageReferences[0].url } },
+            { type: "image_url", role: "reference_image", image_url: { url: imageReferences[1].url } },
+        ]);
+        expect(multiBody).not.toHaveProperty("images");
+        expect(multiBody).not.toHaveProperty("media");
+
+        const frameReferences = [
+            { type: "image", url: "https://cdn.example.com/first.png", role: "first_frame" },
+            { type: "image", url: "https://cdn.example.com/last.png", role: "last_frame" },
+        ];
+        const frameResponse = await POST(request({ model: "video", videoSeconds: "5", size: "16:9" }, frameReferences, { clientRequestId: "newapi-frames" }));
+        const frameInit = (mocks.fetchInternalApi.mock.calls[2] as [string, RequestInit])[1];
+        const frameBody = JSON.parse(String(frameInit.body));
+        expect(frameResponse.status).toBe(200);
+        expect(frameBody.content).toEqual([
+            { type: "image_url", role: "first_frame", image_url: { url: frameReferences[0].url } },
+            { type: "image_url", role: "last_frame", image_url: { url: frameReferences[1].url } },
+        ]);
+
+        const mixedReferences = [
+            { type: "image", url: "https://cdn.example.com/reference.png" },
+            { type: "video", url: "https://cdn.example.com/reference.mp4" },
+            { type: "audio", url: "https://cdn.example.com/reference.mp3" },
+        ];
+        const mixedResponse = await POST(request({ model: "video", videoSeconds: "5", size: "16:9" }, mixedReferences, { clientRequestId: "newapi-mixed" }));
+        const mixedInit = (mocks.fetchInternalApi.mock.calls[3] as [string, RequestInit])[1];
+        const mixedBody = JSON.parse(String(mixedInit.body));
+        expect(mixedResponse.status).toBe(200);
+        expect(mixedBody.content).toEqual([
+            { type: "image_url", role: "reference_image", image_url: { url: mixedReferences[0].url } },
+            { type: "video_url", role: "reference_video", video_url: { url: mixedReferences[1].url } },
+            { type: "audio_url", role: "reference_audio", audio_url: { url: mixedReferences[2].url } },
+        ]);
+    });
+
     it("persists the Drama project, episode and shot task context", async () => {
         mocks.fetchInternalApi.mockResolvedValue(json({ id: "upstream-drama", status: "queued" }));
         const context = { surface: "drama", projectId: "drama-one", episodeId: "episode-one", shotId: "shot-one", estimatedPoints: 8, attemptNo: 2, clientRequestId: "drama-video:one" };
@@ -971,6 +1028,39 @@ function request(config: Record<string, unknown> = { model: "video" }, reference
         },
         body: JSON.stringify({ config, prompt: "A test video", references, context }),
     });
+}
+
+function newApiSettings() {
+    const operation = {
+        capability: "video" as const,
+        source: "manual" as const,
+        protocol: "newapi" as const,
+        apiFormat: "openai" as const,
+        createPath: "/videos",
+        imageToVideoPath: "/videos",
+        queryPath: "/videos/:task_id",
+        requestTemplate: "multipart/form-data: model、prompt、seconds、size、input_reference",
+        resultField: "/videos/:task_id/content",
+        statusField: "status",
+        supportsReferenceImage: true,
+        supportsReferenceVideo: true,
+        supportsReferenceAudio: true,
+    };
+    return {
+        ...settings,
+        systemChannels: [
+            {
+                ...channels[0],
+                advancedConfig: { protocol: "openai" as const, modelCapabilities: { "video-one": "video" as const }, modelConfigs: { "video-one": operation } },
+            },
+        ],
+        logicalModels: [
+            {
+                ...settings.logicalModels[0],
+                bindings: [{ ...settings.logicalModels[0].bindings[0], capabilityProfile: { supportsReferenceImage: true, supportsReferenceVideo: true, supportsReferenceAudio: true, maxReferenceImages: 9 } }],
+            },
+        ],
+    };
 }
 
 function seedanceFrameSettings() {

--- a/web/src/app/api/video-generation-tasks/video-generation-route.ts
+++ b/web/src/app/api/video-generation-tasks/video-generation-route.ts
@@ -135,7 +135,7 @@ export async function POST(request: Request) {
                         if (channel.advancedConfig?.protocol === "yumeng") assertYumengVideoReferences(channel.model, references);
                         assertReferenceUrls(channel.advancedConfig, references, Boolean(globalPreset));
                         const regularReferences = regularVideoReferences(references);
-                        if (channel.advancedConfig?.requestTemplate?.trim().toLowerCase().startsWith("multipart/form-data") && !regularReferences.some((reference) => reference.type === "video" || reference.type === "audio")) {
+                        if (channel.advancedConfig?.requestTemplate?.trim().toLowerCase().startsWith("multipart/form-data") && !usesStructuredReferenceBody(channel.advancedConfig, references)) {
                             assertOpenAiVideoImageReferences(referenceUrls(regularReferences, "image"));
                         }
                     }
@@ -330,7 +330,7 @@ export async function createUpstream(
     const globalPreset = globalAiOpcVideoPreset(channel.advancedConfig, channel.model);
     const requestTemplate = channel.advancedConfig?.requestTemplate?.trim() || "";
     const multipartTemplate = requestTemplate.toLowerCase().startsWith("multipart/form-data");
-    const structuredOpenAiReferences = multipartTemplate && Boolean(videos.length || audios.length);
+    const structuredOpenAiReferences = multipartTemplate && usesStructuredReferenceBody(channel.advancedConfig, references);
     const multipart = multipartTemplate && !structuredOpenAiReferences;
     let requestBody: FormData | string;
     try {
@@ -343,7 +343,7 @@ export async function createUpstream(
                     duration: values.duration,
                     resolution: values.resolution,
                     ratio: values.ratio,
-                    content: values.content,
+                    content: channel.advancedConfig?.protocol === "newapi" ? videoReferenceMediaContent(references) : values.content,
                     generate_audio: generateAudio,
                     watermark: booleanValue(raw.videoWatermark),
                 }
@@ -617,16 +617,22 @@ function referenceUrls(items: readonly VideoGenerationReference[], type: VideoGe
 }
 
 function videoReferenceContent(prompt: string, references: readonly VideoGenerationReference[]) {
-    return [
-        { type: "text", text: prompt },
-        ...references.map((reference) =>
-            reference.type === "image"
-                ? { type: "image_url", role: reference.role === "first_frame" || reference.role === "last_frame" ? reference.role : "reference_image", image_url: { url: reference.url } }
-                : reference.type === "video"
-                  ? { type: "video_url", role: "reference_video", video_url: { url: reference.url } }
-                  : { type: "audio_url", role: "reference_audio", audio_url: { url: reference.url } },
-        ),
-    ];
+    return [{ type: "text", text: prompt }, ...videoReferenceMediaContent(references)];
+}
+function videoReferenceMediaContent(references: readonly VideoGenerationReference[]) {
+    return references.map((reference) =>
+        reference.type === "image"
+            ? { type: "image_url", role: reference.role === "first_frame" || reference.role === "last_frame" ? reference.role : "reference_image", image_url: { url: reference.url } }
+            : reference.type === "video"
+              ? { type: "video_url", role: "reference_video", video_url: { url: reference.url } }
+              : { type: "audio_url", role: "reference_audio", audio_url: { url: reference.url } },
+    );
+}
+function usesStructuredReferenceBody(config: NonNullable<ReturnType<typeof toSystemGenerationChannel>>["advancedConfig"], references: readonly VideoGenerationReference[]) {
+    const regularReferences = regularVideoReferences(references);
+    if (regularReferences.some((reference) => reference.type === "video" || reference.type === "audio")) return true;
+    if (config?.protocol !== "newapi") return false;
+    return regularReferences.filter((reference) => reference.type === "image").length > 1 || references.some((reference) => reference.role === "first_frame" || reference.role === "last_frame");
 }
 function requestPublicOrigin(request: Request) {
     return resolvePublicRequestOrigin(request);

--- a/web/src/app/api/video-generation-tasks/video-generation-route.ts
+++ b/web/src/app/api/video-generation-tasks/video-generation-route.ts
@@ -29,7 +29,7 @@ import { systemAiBillingHeaders } from "@/lib/server/system-ai-billing";
 import { maintenanceWorkerContextHeaders, requestRuntimeCredential } from "@/lib/server/maintenance-auth";
 import { resolvePublicRequestOrigin } from "@/lib/server/public-request-origin";
 import { writeVideoGenerationLog } from "@/lib/server/video-task-log";
-import { buildOpenAiVideoFormData } from "./video-task-openai";
+import { assertOpenAiVideoImageReferences, buildOpenAiVideoFormData } from "./video-task-openai";
 import { normalizeVideoGenerationReferences, regularVideoReferences, videoFrameReferences, type VideoGenerationReference } from "@/lib/video-reference-contract";
 import { assertYumengVideoReferences, buildYumengVideoRequest } from "@/lib/yumeng-model-center";
 import { normalizeVideoProviderImageReferences } from "@/lib/server/video-reference-image";
@@ -134,6 +134,10 @@ export async function POST(request: Request) {
                         if (channel.advancedConfig?.protocol === "vozeb-recommended") assertVozebRecommendedVideoReferences(channel.model, references);
                         if (channel.advancedConfig?.protocol === "yumeng") assertYumengVideoReferences(channel.model, references);
                         assertReferenceUrls(channel.advancedConfig, references, Boolean(globalPreset));
+                        const regularReferences = regularVideoReferences(references);
+                        if (channel.advancedConfig?.requestTemplate?.trim().toLowerCase().startsWith("multipart/form-data") && !regularReferences.some((reference) => reference.type === "video" || reference.type === "audio")) {
+                            assertOpenAiVideoImageReferences(referenceUrls(regularReferences, "image"));
+                        }
                     }
                 } catch (error) {
                     capabilityError = error;
@@ -210,8 +214,9 @@ export async function POST(request: Request) {
                     }
                     const message = toSafeGenerationErrorMessage(error, "视频任务创建失败");
                     if (!(error instanceof SafeCandidateFailure)) {
-                        await scheduleGenerationTask("video", localTask.id, { executionPhase: "needs_review", nextPollAt: undefined, lastUpstreamStatus: "submission_outcome_unknown" });
-                        return NextResponse.json({ task: { ...publicTask({ ...localTask, attempts }), needsReview: true }, warning: `${message}；上游创建结果待确认，系统不会自动重复创建。` }, { status: 202 });
+                        const reviewReason = `${message}；上游创建结果待确认，系统不会自动重复创建。`;
+                        await scheduleGenerationTask("video", localTask.id, { executionPhase: "needs_review", nextPollAt: undefined, lastUpstreamStatus: "submission_outcome_unknown", resultPayload: { reviewReason: reviewReason.slice(0, 500) } });
+                        return NextResponse.json({ task: { ...publicTask({ ...localTask, attempts }), needsReview: true }, warning: reviewReason }, { status: 202 });
                     }
                     break;
                 }
@@ -327,73 +332,78 @@ export async function createUpstream(
     const multipartTemplate = requestTemplate.toLowerCase().startsWith("multipart/form-data");
     const structuredOpenAiReferences = multipartTemplate && Boolean(videos.length || audios.length);
     const multipart = multipartTemplate && !structuredOpenAiReferences;
-    const payload = multipart
-        ? undefined
-        : structuredOpenAiReferences
-          ? {
-                model: channel.model,
-                prompt,
-                duration: values.duration,
-                resolution: values.resolution,
-                ratio: values.ratio,
-                content: values.content,
-                generate_audio: generateAudio,
-                watermark: booleanValue(raw.videoWatermark),
-            }
-          : channel.advancedConfig?.protocol === "vozeb-recommended"
-            ? buildVozebRecommendedVideoRequest({
-                  model: channel.model,
-                  prompt,
-                  duration: values.duration as number,
-                  aspectRatio: values.aspect_ratio as string,
-                  resolution: values.resolution as string,
-                  generateAudio,
-                  images,
-                  videos,
-                  audios,
-              })
-            : channel.advancedConfig?.protocol === "seedance-special"
-              ? buildSeedanceSpecialRequest({
+    let requestBody: FormData | string;
+    try {
+        const payload = multipart
+            ? undefined
+            : structuredOpenAiReferences
+              ? {
                     model: channel.model,
                     prompt,
-                    duration: values.duration === -1 ? 5 : (values.duration as number),
-                    ratio: (values.ratio as string | undefined) || "adaptive",
-                    generateAudio,
-                    references,
-                })
-              : channel.advancedConfig?.protocol === "yumeng"
-                ? buildYumengVideoRequest({
+                    duration: values.duration,
+                    resolution: values.resolution,
+                    ratio: values.ratio,
+                    content: values.content,
+                    generate_audio: generateAudio,
+                    watermark: booleanValue(raw.videoWatermark),
+                }
+              : channel.advancedConfig?.protocol === "vozeb-recommended"
+                ? buildVozebRecommendedVideoRequest({
                       model: channel.model,
                       prompt,
                       duration: values.duration as number,
                       aspectRatio: values.aspect_ratio as string,
                       resolution: values.resolution as string,
                       generateAudio,
-                      watermark: booleanValue(raw.videoWatermark),
-                      images: requestImages,
+                      images,
                       videos,
                       audios,
-                      firstFrame: firstFrameUrl || undefined,
-                      lastFrame: lastFrameUrl || undefined,
                   })
-                : globalPreset
-                  ? buildGlobalAiOpcVideoRequest(globalPreset, {
+                : channel.advancedConfig?.protocol === "seedance-special"
+                  ? buildSeedanceSpecialRequest({
                         model: channel.model,
                         prompt,
-                        duration: values.duration as number,
-                        ratio: values.ratio as string,
-                        resolution: values.resolution as string,
-                        images: requestImages.length ? requestImages : requestImage ? [requestImage] : [],
-                        videos,
-                        audios,
+                        duration: values.duration === -1 ? 5 : (values.duration as number),
+                        ratio: (values.ratio as string | undefined) || "adaptive",
                         generateAudio,
-                        firstFrame: firstFrameUrl || undefined,
-                        lastFrame: lastFrameUrl || undefined,
+                        references,
                     })
-                  : buildVideoProviderRequest(requestTemplate, defaults, values);
-    const requestBody = multipart
-        ? await buildOpenAiVideoFormData({ model: channel.model, prompt, seconds: values.seconds as number, width: dimensions.width, height: dimensions.height, imageUrls: firstFrameUrl ? [firstFrameUrl] : images, origin, cookie })
-        : JSON.stringify(payload);
+                  : channel.advancedConfig?.protocol === "yumeng"
+                    ? buildYumengVideoRequest({
+                          model: channel.model,
+                          prompt,
+                          duration: values.duration as number,
+                          aspectRatio: values.aspect_ratio as string,
+                          resolution: values.resolution as string,
+                          generateAudio,
+                          watermark: booleanValue(raw.videoWatermark),
+                          images: requestImages,
+                          videos,
+                          audios,
+                          firstFrame: firstFrameUrl || undefined,
+                          lastFrame: lastFrameUrl || undefined,
+                      })
+                    : globalPreset
+                      ? buildGlobalAiOpcVideoRequest(globalPreset, {
+                            model: channel.model,
+                            prompt,
+                            duration: values.duration as number,
+                            ratio: values.ratio as string,
+                            resolution: values.resolution as string,
+                            images: requestImages.length ? requestImages : requestImage ? [requestImage] : [],
+                            videos,
+                            audios,
+                            generateAudio,
+                            firstFrame: firstFrameUrl || undefined,
+                            lastFrame: lastFrameUrl || undefined,
+                        })
+                      : buildVideoProviderRequest(requestTemplate, defaults, values);
+        requestBody = multipart
+            ? await buildOpenAiVideoFormData({ model: channel.model, prompt, seconds: values.seconds as number, width: dimensions.width, height: dimensions.height, imageUrls: firstFrameUrl ? [firstFrameUrl] : images, origin, cookie })
+            : JSON.stringify(payload);
+    } catch (error) {
+        throw new SafeCandidateFailure(error instanceof Error ? error.message : "视频请求参数无法构建");
+    }
     const imageToVideoPath = images.length || firstFrameUrl ? channel.advancedConfig?.imageToVideoPath?.trim() : "";
     const createPaths = globalPreset ? [globalPreset.createPath] : imageToVideoPath ? [imageToVideoPath] : resolvedProviderCreatePaths(channel.advancedConfig, "video", CREATE_PATHS);
     for (const path of createPaths) {

--- a/web/src/app/api/video-generation-tasks/video-generation-route.ts
+++ b/web/src/app/api/video-generation-tasks/video-generation-route.ts
@@ -340,57 +340,57 @@ export async function createUpstream(
                 generate_audio: generateAudio,
                 watermark: booleanValue(raw.videoWatermark),
             }
-        : channel.advancedConfig?.protocol === "vozeb-recommended"
-          ? buildVozebRecommendedVideoRequest({
-                model: channel.model,
-                prompt,
-                duration: values.duration as number,
-                aspectRatio: values.aspect_ratio as string,
-                resolution: values.resolution as string,
-                generateAudio,
-                images,
-                videos,
-                audios,
-            })
-          : channel.advancedConfig?.protocol === "seedance-special"
-            ? buildSeedanceSpecialRequest({
+          : channel.advancedConfig?.protocol === "vozeb-recommended"
+            ? buildVozebRecommendedVideoRequest({
                   model: channel.model,
                   prompt,
-                  duration: values.duration === -1 ? 5 : (values.duration as number),
-                  ratio: (values.ratio as string | undefined) || "adaptive",
+                  duration: values.duration as number,
+                  aspectRatio: values.aspect_ratio as string,
+                  resolution: values.resolution as string,
                   generateAudio,
-                  references,
+                  images,
+                  videos,
+                  audios,
               })
-            : channel.advancedConfig?.protocol === "yumeng"
-              ? buildYumengVideoRequest({
+            : channel.advancedConfig?.protocol === "seedance-special"
+              ? buildSeedanceSpecialRequest({
                     model: channel.model,
                     prompt,
-                    duration: values.duration as number,
-                    aspectRatio: values.aspect_ratio as string,
-                    resolution: values.resolution as string,
+                    duration: values.duration === -1 ? 5 : (values.duration as number),
+                    ratio: (values.ratio as string | undefined) || "adaptive",
                     generateAudio,
-                    watermark: booleanValue(raw.videoWatermark),
-                    images: requestImages,
-                    videos,
-                    audios,
-                    firstFrame: firstFrameUrl || undefined,
-                    lastFrame: lastFrameUrl || undefined,
+                    references,
                 })
-              : globalPreset
-                ? buildGlobalAiOpcVideoRequest(globalPreset, {
+              : channel.advancedConfig?.protocol === "yumeng"
+                ? buildYumengVideoRequest({
                       model: channel.model,
                       prompt,
                       duration: values.duration as number,
-                      ratio: values.ratio as string,
+                      aspectRatio: values.aspect_ratio as string,
                       resolution: values.resolution as string,
-                      images: requestImages.length ? requestImages : requestImage ? [requestImage] : [],
+                      generateAudio,
+                      watermark: booleanValue(raw.videoWatermark),
+                      images: requestImages,
                       videos,
                       audios,
-                      generateAudio,
                       firstFrame: firstFrameUrl || undefined,
                       lastFrame: lastFrameUrl || undefined,
                   })
-                : buildVideoProviderRequest(requestTemplate, defaults, values);
+                : globalPreset
+                  ? buildGlobalAiOpcVideoRequest(globalPreset, {
+                        model: channel.model,
+                        prompt,
+                        duration: values.duration as number,
+                        ratio: values.ratio as string,
+                        resolution: values.resolution as string,
+                        images: requestImages.length ? requestImages : requestImage ? [requestImage] : [],
+                        videos,
+                        audios,
+                        generateAudio,
+                        firstFrame: firstFrameUrl || undefined,
+                        lastFrame: lastFrameUrl || undefined,
+                    })
+                  : buildVideoProviderRequest(requestTemplate, defaults, values);
     const requestBody = multipart
         ? await buildOpenAiVideoFormData({ model: channel.model, prompt, seconds: values.seconds as number, width: dimensions.width, height: dimensions.height, imageUrls: firstFrameUrl ? [firstFrameUrl] : images, origin, cookie })
         : JSON.stringify(payload);

--- a/web/src/app/api/video-generation-tasks/video-generation-route.ts
+++ b/web/src/app/api/video-generation-tasks/video-generation-route.ts
@@ -323,9 +323,23 @@ export async function createUpstream(
         ...(lastFrameUrl ? { last_frame: lastFrameUrl, last_frame_url: lastFrameUrl } : {}),
     };
     const globalPreset = globalAiOpcVideoPreset(channel.advancedConfig, channel.model);
-    const multipart = channel.advancedConfig?.requestTemplate?.trim().toLowerCase().startsWith("multipart/form-data") === true;
+    const requestTemplate = channel.advancedConfig?.requestTemplate?.trim() || "";
+    const multipartTemplate = requestTemplate.toLowerCase().startsWith("multipart/form-data");
+    const structuredOpenAiReferences = multipartTemplate && Boolean(videos.length || audios.length);
+    const multipart = multipartTemplate && !structuredOpenAiReferences;
     const payload = multipart
         ? undefined
+        : structuredOpenAiReferences
+          ? {
+                model: channel.model,
+                prompt,
+                duration: values.duration,
+                resolution: values.resolution,
+                ratio: values.ratio,
+                content: values.content,
+                generate_audio: generateAudio,
+                watermark: booleanValue(raw.videoWatermark),
+            }
         : channel.advancedConfig?.protocol === "vozeb-recommended"
           ? buildVozebRecommendedVideoRequest({
                 model: channel.model,
@@ -376,7 +390,7 @@ export async function createUpstream(
                       firstFrame: firstFrameUrl || undefined,
                       lastFrame: lastFrameUrl || undefined,
                   })
-                : buildVideoProviderRequest(channel.advancedConfig?.requestTemplate, defaults, values);
+                : buildVideoProviderRequest(requestTemplate, defaults, values);
     const requestBody = multipart
         ? await buildOpenAiVideoFormData({ model: channel.model, prompt, seconds: values.seconds as number, width: dimensions.width, height: dimensions.height, imageUrls: firstFrameUrl ? [firstFrameUrl] : images, origin, cookie })
         : JSON.stringify(payload);

--- a/web/src/app/api/video-generation-tasks/video-task-openai.ts
+++ b/web/src/app/api/video-generation-tasks/video-task-openai.ts
@@ -12,7 +12,7 @@ type OpenAiVideoFormInput = {
 };
 
 export async function buildOpenAiVideoFormData(input: OpenAiVideoFormInput) {
-    if (input.imageUrls.length > 1) throw new Error("OpenAI 视频协议最多支持 1 张参考图");
+    assertOpenAiVideoImageReferences(input.imageUrls);
     const formData = new FormData();
     formData.set("model", input.model);
     formData.set("prompt", input.prompt);
@@ -23,4 +23,8 @@ export async function buildOpenAiVideoFormData(input: OpenAiVideoFormInput) {
         formData.set("input_reference", file);
     }
     return formData;
+}
+
+export function assertOpenAiVideoImageReferences(imageUrls: string[]) {
+    if (imageUrls.length > 1) throw new Error("OpenAI 视频协议最多支持 1 张参考图");
 }

--- a/web/src/lib/channel-protocol-registry.test.ts
+++ b/web/src/lib/channel-protocol-registry.test.ts
@@ -56,7 +56,10 @@ describe("channel protocol registry", () => {
             audio: { createPath: "/audio/speech" },
         });
         expect(channelProtocolDefinition("sub2api").operations.image).toMatchObject({ createPath: "/images/generations", editPath: "/images/generations", requestTemplate: expect.stringContaining("image_urls") });
-        expect(channelProtocolDefinition("newapi").operations).toEqual(channelProtocolDefinition("openai").operations);
+        expect(channelProtocolDefinition("newapi").operations).toMatchObject({
+            ...channelProtocolDefinition("openai").operations,
+            video: { supportsReferenceImage: true, supportsReferenceVideo: true, supportsReferenceAudio: true, referenceRule: expect.stringContaining("JSON content") },
+        });
         expect(channelProtocolDefinition("seedance").operations.video).toMatchObject({ createPath: "/contents/generations/tasks", queryPath: "/contents/generations/tasks/:task_id", resultField: "content.video_url" });
         expect(channelProtocolDefinition("volcengine-video").operations.video).toEqual(channelProtocolDefinition("seedance").operations.video);
         expect(channelProtocolDefinition("stable-diffusion").operations.image).toMatchObject({ createPath: "/sdapi/v1/txt2img", editPath: "/sdapi/v1/img2img", resultField: "images[0]" });

--- a/web/src/lib/channel-protocol-registry.ts
+++ b/web/src/lib/channel-protocol-registry.ts
@@ -47,6 +47,17 @@ const openAiOperations: ChannelProtocolDefinition["operations"] = {
     audio: { capability: "audio", createPath: "/audio/speech", requestTemplate: '{"model":"{{model}}","input":"{{prompt}}","voice":"alloy","response_format":"mp3"}', resultField: "binary" },
 };
 
+const newApiOperations: ChannelProtocolDefinition["operations"] = {
+    ...openAiOperations,
+    video: {
+        ...openAiOperations.video!,
+        referenceRule: "单张普通参考图使用 multipart/form-data input_reference；多图、首尾帧或视频/音频参考使用 JSON content 多模态数组。",
+        supportsReferenceImage: true,
+        supportsReferenceVideo: true,
+        supportsReferenceAudio: true,
+    },
+};
+
 const geminiVideoOperation: ProtocolOperation = {
     capability: "video",
     createPath: "/models/:model:predictLongRunning",
@@ -212,12 +223,12 @@ export const registeredChannelProtocolDefinitions: ChannelProtocolDefinition[] =
     {
         id: "newapi",
         label: "New API",
-        description: "New API 聚合网关，按 OpenAI 路径调用并保留独立协议身份。",
+        description: "New API 聚合网关，按 OpenAI 路径调用，视频支持 content 多模态参考素材。",
         apiFormat: "openai",
         authMode: "bearer",
         modelCatalogPaths: ["/v1/models"],
         capabilities: ["text", "image", "video", "audio"],
-        operations: openAiOperations,
+        operations: newApiOperations,
         strict: true,
     },
     {

--- a/web/src/lib/server/agent-run-executor.test.ts
+++ b/web/src/lib/server/agent-run-executor.test.ts
@@ -854,8 +854,22 @@ describe("executeAgentRun backend settings", () => {
         expect(JSON.parse(String(createCall?.[1]?.body))).toMatchObject({ source: "agent", config: { size: "1080x1213" }, references: [{ url: "https://cdn.example.com/source.png" }, { url: "https://cdn.example.com/style.png" }] });
     });
 
-    it("uses completed dependency assets as real references for downstream video", async () => {
-        mocks.run = runWithTasks([imageTask("image-one"), { id: "video-one", title: "角色动画", type: "video", model: "video-model", prompt: "让角色缓慢转身", count: 1, dependencies: ["image-one"], status: "ready", attempts: 0 }]);
+    it("merges direct and completed dependency references for downstream video", async () => {
+        mocks.run = runWithTasks([
+            imageTask("image-one"),
+            {
+                id: "video-one",
+                title: "角色动画",
+                type: "video",
+                model: "video-model",
+                prompt: "让角色缓慢转身",
+                count: 1,
+                dependencies: ["image-one"],
+                status: "ready",
+                attempts: 0,
+                references: [{ assetId: "product", type: "image", url: "https://cdn.example.com/product.png" }],
+            },
+        ]);
         const nextSettings = settings("image-model", "image-channel") as unknown as {
             defaultModels: { videoModel: string };
             systemChannels: Array<Record<string, unknown>>;
@@ -896,8 +910,20 @@ describe("executeAgentRun backend settings", () => {
         await executeAgentRun(mocks.run, "http://localhost", "session=test");
 
         const videoCall = mocks.fetchInternalApi.mock.calls.find(([url, init]) => init?.method === "POST" && String(url).endsWith("/api/video-generation-tasks"));
-        expect(JSON.parse(String(videoCall?.[1]?.body))).toMatchObject({ references: [{ type: "image", url: "https://cdn.example.com/dependency.png" }] });
-        expect(mocks.run?.tasks[1]).toMatchObject({ status: "completed", referenceAssetId: "asset-0", references: [{ assetId: "asset-0", url: "https://cdn.example.com/dependency.png", type: "image" }] });
+        expect(JSON.parse(String(videoCall?.[1]?.body))).toMatchObject({
+            references: [
+                { type: "image", url: "https://cdn.example.com/product.png" },
+                { type: "image", url: "https://cdn.example.com/dependency.png" },
+            ],
+        });
+        expect(mocks.run?.tasks[1]).toMatchObject({
+            status: "completed",
+            referenceAssetId: "product",
+            references: [
+                { assetId: "product", url: "https://cdn.example.com/product.png", type: "image" },
+                { assetId: "asset-0", url: "https://cdn.example.com/dependency.png", type: "image" },
+            ],
+        });
     });
 
     it("dispatches explicit video frame roles unchanged to the video route", async () => {

--- a/web/src/lib/server/generation-channel.test.ts
+++ b/web/src/lib/server/generation-channel.test.ts
@@ -55,8 +55,23 @@ describe("resolveSystemGenerationChannel", () => {
     });
 
     it("uses the effective logical binding reference capabilities at runtime", () => {
-        const channel = { id: "one", name: "One", enabled: true, baseUrl: "https://one.example.com/v1", apiKey: "secret", apiFormat: "openai" as const, models: ["video-one"], advancedConfig: { protocol: "openai", supportsReferenceImage: true, supportsReferenceVideo: false, supportsReferenceAudio: false } as never };
-        const resolved = { logicalModelId: "video", upstreamModel: "video-one", channelId: "one", channel, capabilityProfile: { supportsReferenceImage: true, supportsReferenceVideo: true, supportsReferenceAudio: false, supportsAsync: true, supportsCancel: false, supportsWebhook: false } };
+        const channel = {
+            id: "one",
+            name: "One",
+            enabled: true,
+            baseUrl: "https://one.example.com/v1",
+            apiKey: "secret",
+            apiFormat: "openai" as const,
+            models: ["video-one"],
+            advancedConfig: { protocol: "openai", supportsReferenceImage: true, supportsReferenceVideo: false, supportsReferenceAudio: false } as never,
+        };
+        const resolved = {
+            logicalModelId: "video",
+            upstreamModel: "video-one",
+            channelId: "one",
+            channel,
+            capabilityProfile: { supportsReferenceImage: true, supportsReferenceVideo: true, supportsReferenceAudio: false, supportsAsync: true, supportsCancel: false, supportsWebhook: false },
+        };
 
         expect(toSystemGenerationChannel(resolved as never).advancedConfig).toMatchObject({ supportsReferenceImage: true, supportsReferenceVideo: true, supportsReferenceAudio: false });
     });

--- a/web/src/lib/server/generation-channel.test.ts
+++ b/web/src/lib/server/generation-channel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { channelSupportsModel, generationModelId, resolveModelAdvancedConfig, resolveSystemGenerationChannel, systemGenerationChannelId } from "./generation-channel";
+import { channelSupportsModel, generationModelId, resolveModelAdvancedConfig, resolveSystemGenerationChannel, systemGenerationChannelId, toSystemGenerationChannel } from "./generation-channel";
 
 const channels = [{ id: "channel-1", enabled: true, apiFormat: "gemini" as const, models: ["models/video-v1"] }];
 
@@ -52,5 +52,12 @@ describe("resolveSystemGenerationChannel", () => {
 
         expect(resolveModelAdvancedConfig(advanced, "openai-text")).toMatchObject({ createPath: "/chat/completions", queryPath: "" });
         expect(resolveModelAdvancedConfig(advanced, "sd2.0")).toMatchObject({ protocol: "seedance", createPath: "/videos", queryPath: "/videos/:task_id" });
+    });
+
+    it("uses the effective logical binding reference capabilities at runtime", () => {
+        const channel = { id: "one", name: "One", enabled: true, baseUrl: "https://one.example.com/v1", apiKey: "secret", apiFormat: "openai" as const, models: ["video-one"], advancedConfig: { protocol: "openai", supportsReferenceImage: true, supportsReferenceVideo: false, supportsReferenceAudio: false } as never };
+        const resolved = { logicalModelId: "video", upstreamModel: "video-one", channelId: "one", channel, capabilityProfile: { supportsReferenceImage: true, supportsReferenceVideo: true, supportsReferenceAudio: false, supportsAsync: true, supportsCancel: false, supportsWebhook: false } };
+
+        expect(toSystemGenerationChannel(resolved as never).advancedConfig).toMatchObject({ supportsReferenceImage: true, supportsReferenceVideo: true, supportsReferenceAudio: false });
     });
 });

--- a/web/src/lib/server/generation-channel.ts
+++ b/web/src/lib/server/generation-channel.ts
@@ -45,6 +45,7 @@ export function resolveSystemGenerationChannel(config: { apiSource?: string; bas
 
 export function toSystemGenerationChannel(resolved: ResolvedLogicalModel): SystemGenerationChannelConfig {
     const modelConfig = resolveChannelModelConfig(resolved.channel.advancedConfig, resolved.upstreamModel);
+    const advancedConfig = resolveModelAdvancedConfig(resolved.channel.advancedConfig, resolved.upstreamModel);
     return {
         apiSource: "system",
         baseUrl: `/api/ai/system/${encodeURIComponent(resolved.channelId)}`,
@@ -53,7 +54,15 @@ export function toSystemGenerationChannel(resolved: ResolvedLogicalModel): Syste
         model: resolved.upstreamModel,
         channelId: resolved.channelId,
         logicalModel: resolved.logicalModelId,
-        advancedConfig: resolveModelAdvancedConfig(resolved.channel.advancedConfig, resolved.upstreamModel),
+        advancedConfig:
+            advancedConfig && resolved.capabilityProfile
+                ? {
+                      ...advancedConfig,
+                      supportsReferenceImage: resolved.capabilityProfile.supportsReferenceImage,
+                      supportsReferenceVideo: resolved.capabilityProfile.supportsReferenceVideo,
+                      supportsReferenceAudio: resolved.capabilityProfile.supportsReferenceAudio,
+                  }
+                : advancedConfig,
         capabilityProfile: resolved.capabilityProfile,
     };
 }

--- a/web/src/lib/server/generation-errors.test.ts
+++ b/web/src/lib/server/generation-errors.test.ts
@@ -16,6 +16,13 @@ describe("generation error messages", () => {
         expect(toSafeGenerationErrorMessage(new Error("<html><head><title>502 Bad Gateway</title></head><body><center><h1>502 Bad Gateway</h1></center><hr><center>nginx</center></body></html>"), "生成失败")).toBe(DEFAULT_CHANNEL_CONNECT_ERROR);
     });
 
+    it("keeps safe upstream HTTP details while removing the host", () => {
+        const error = new GenerationSubmissionUncertainError("图片生成失败，上游返回了网页错误（HTTP 502，地址 https://provider.example/v1/images/edits，类型 text/html; charset=UTF-8），请检查网关状态");
+
+        expect(toSafeGenerationErrorMessage(error, "生成失败")).toBe("图片生成失败：上游接口 /v1/images/edits 返回 HTTP 502（text/html; charset=UTF-8）");
+        expect(toSafeGenerationReviewReason(error, "生成失败")).toBe("图片生成失败：上游接口 /v1/images/edits 返回 HTTP 502（text/html; charset=UTF-8）；创建结果无法确认，为避免重复生成和扣费，系统已停止自动重试。");
+    });
+
     it("does not mislabel an uncertain upstream submission as a missing reference", () => {
         expect(toSafeGenerationReviewReason(new GenerationSubmissionUncertainError("参考图处理失败：https://provider.example/images/edits"), "图片任务创建结果未知")).toBe(UNKNOWN_SUBMISSION_REVIEW_ERROR);
     });

--- a/web/src/lib/server/generation-errors.ts
+++ b/web/src/lib/server/generation-errors.ts
@@ -10,14 +10,33 @@ export function toSafeGenerationErrorMessage(error: unknown, fallback: string) {
     if (hasInsufficientPointsError(error)) return "积分不足";
     if (isTimeoutError(error, message)) return "生成接口响应超时，请稍后重试或检查模型服务。";
     if (isFetchNetworkError(error, message)) return DEFAULT_CHANNEL_CONNECT_ERROR;
+    const upstreamHttpError = publicUpstreamHttpError(message);
+    if (upstreamHttpError) return upstreamHttpError;
     if (isHtmlGatewayError(message)) return DEFAULT_CHANNEL_CONNECT_ERROR;
     if (containsInfrastructureDetails(message)) return /参考|素材|公网/i.test(message) ? "参考素材暂时无法提交给当前生成渠道，请重新上传或稍后重试。" : DEFAULT_CHANNEL_CONNECT_ERROR;
     return message || fallback;
 }
 
 export function toSafeGenerationReviewReason(error: unknown, fallback: string) {
-    if (error instanceof GenerationSubmissionUncertainError) return UNKNOWN_SUBMISSION_REVIEW_ERROR;
+    if (error instanceof GenerationSubmissionUncertainError) {
+        const upstreamHttpError = publicUpstreamHttpError(error.message);
+        return upstreamHttpError ? `${upstreamHttpError}；创建结果无法确认，为避免重复生成和扣费，系统已停止自动重试。` : UNKNOWN_SUBMISSION_REVIEW_ERROR;
+    }
     return toSafeGenerationErrorMessage(error, fallback);
+}
+
+function publicUpstreamHttpError(message: string) {
+    const match = message.match(/^(.*?)，?上游返回了网页错误（HTTP\s+(\d{3})(?:，地址\s+(https?:\/\/[^，）\s]+))?(?:，类型\s+([^）]+))?）/u);
+    if (!match) return "";
+    let path = "";
+    try {
+        path = new URL(match[3]).pathname.slice(0, 160);
+    } catch {
+        path = "";
+    }
+    const contentType = match[4]?.trim().match(/^[\w.+-]+\/[\w.+-]+(?:;\s*charset=[\w-]+)?$/i)?.[0];
+    const label = match[1].trim().replace(/[，,:：]+$/u, "") || "生成失败";
+    return `${label}：上游接口${path ? ` ${path}` : ""} 返回 HTTP ${match[2]}${contentType ? `（${contentType}）` : ""}`;
 }
 
 function generationErrorMessage(error: unknown) {

--- a/web/src/lib/server/generation-operations-service.test.ts
+++ b/web/src/lib/server/generation-operations-service.test.ts
@@ -213,7 +213,7 @@ describe("generation operations aggregation", () => {
 
     it("shows the persisted review reason when a task has no terminal error", async () => {
         mocks.listStoredGenerationTaskRecords.mockResolvedValue({
-            items: [{ ...task(), type: "image", status: "running", executionPhase: "needs_review", payload: { config: { model: "image-model" } }, resultPayload: { reviewReason: "生成渠道暂时无法连接，请稍后重试或联系管理员。" } }],
+            items: [{ ...task(), type: "image", status: "running", executionPhase: "needs_review", payload: { config: { model: "image-model" } }, resultPayload: { reviewReason: "图片生成失败：上游接口 /v1/images/edits 返回 HTTP 502" } }],
             all: [],
             total: 1,
             page: 1,
@@ -223,7 +223,7 @@ describe("generation operations aggregation", () => {
 
         const result = await listAdminGenerationOperations({ page: 1 });
 
-        expect(result.items[0]).toMatchObject({ canReview: true, error: "生成渠道暂时无法连接，请稍后重试或联系管理员。" });
+        expect(result.items[0]).toMatchObject({ canReview: true, error: "图片生成失败：上游接口 /v1/images/edits 返回 HTTP 502" });
     });
 
     it("explains a legacy uncertain submission when no reason was persisted", async () => {

--- a/web/src/lib/server/provider-task-config.test.ts
+++ b/web/src/lib/server/provider-task-config.test.ts
@@ -111,6 +111,7 @@ describe("provider task config", () => {
 
         expect(() => assertVideoReferenceRoles({ protocol: "seedance" } as never, frames)).not.toThrow();
         expect(() => assertVideoReferenceRoles({ protocol: "yumeng", requestTemplate: '{"first_image":"{{first_frame}}","last_image":"{{last_frame}}"}' } as never, frames)).not.toThrow();
+        expect(() => assertVideoReferenceRoles({ protocol: "newapi" } as never, frames)).not.toThrow();
         expect(() => assertVideoReferenceRoles({ protocol: "openai" } as never, frames)).toThrow("当前视频模型不支持尾帧输入");
         expect(() => assertVideoReferenceRoles({ protocol: "custom", requestTemplate: '{"first":"{{first_frame_url}}","last":"{{last_frame_url}}"}' } as never, frames)).not.toThrow();
         expect(() => assertVideoReferenceRoles({ protocol: "custom", requestTemplate: '{"first":"{{first_frame_url}}"}' } as never, frames)).toThrow("当前视频模型不支持尾帧输入");

--- a/web/src/lib/server/provider-task-config.ts
+++ b/web/src/lib/server/provider-task-config.ts
@@ -116,11 +116,13 @@ export function assertVideoReferenceRoles(config: SystemChannelAdvancedConfig | 
                 ? ["reference", "first_frame", "last_frame"]
                 : protocol === "yumeng"
                   ? templateVideoReferenceRoles(config?.requestTemplate)
-                  : protocol === "openai" || protocol === "newapi" || protocol === "sub2api"
-                    ? ["reference", "first_frame"]
-                    : protocol === "custom" || protocol === "compatible" || protocol === "auto"
-                      ? templateVideoReferenceRoles(config?.requestTemplate)
-                      : ["reference"]),
+                  : protocol === "newapi"
+                    ? ["reference", "first_frame", "last_frame"]
+                    : protocol === "openai" || protocol === "sub2api"
+                      ? ["reference", "first_frame"]
+                      : protocol === "custom" || protocol === "compatible" || protocol === "auto"
+                        ? templateVideoReferenceRoles(config?.requestTemplate)
+                        : ["reference"]),
     );
     const unsupported = requestedRoles.find((role) => !supported.has(role));
     if (unsupported) throw new Error(unsupported === "last_frame" ? "当前视频模型不支持尾帧输入" : "当前视频模型不支持显式首帧输入");


### PR DESCRIPTION
## 背景

逻辑模型绑定允许单独声明参考图片、视频和音频能力，但运行时曾可能只读取渠道协议默认能力，导致绑定层已启用的参考素材被错误拒绝。OpenAI 兼容 `/videos` 的单参考图仍需要 multipart；New API 对多图、首尾帧、参考视频或音频需要结构化 `content[]` JSON。

此外，本地协议或请求体构建错误发生在请求真正发出之前，不应进入 `submission_outcome_unknown`；网页网关错误也应保留安全、可定位的诊断信息。

## 改动

- 将逻辑模型绑定解析后的有效 `supportsReferenceImage/Video/Audio` 写入运行时渠道能力；绑定未配置时继续继承模型、协议或渠道默认值。
- OpenAI 单普通参考图继续发送 `multipart/form-data` 的 `input_reference`，并在多于 1 张时于上游请求前返回明确 400。
- 为 New API 注册独立视频参考素材能力：多图、首尾帧、参考视频或音频改用 JSON `content[]`。
- New API 的 `content[]` 只放媒体项，公开提示词保留在顶层 `prompt`；不发送多套冗余兼容字段。
- New API 支持首帧、尾帧以及绑定声明的多参考图数量限制；Agent 运行时沿用同一能力约束。
- 本地协议和请求构建错误按确定性失败处理，不再误进入待人工确认状态。
- 未知提交状态持久化安全 `reviewReason`；网页网关错误仅保留 HTTP 状态、接口路径和内容类型。
- 后台生成运维继续复用持久化诊断原因，不改变任务状态、计费或重试语义。

## 验证

- 在本 PR 官方 `main` 基线上补充独立提交 `2d9c984`。
- New API 多参考素材专项：4 个文件、115 项测试通过。
- TypeScript 与 `git diff --check` 通过。
- 同一增量在私有稳定分支已通过协议夹具 125/125、全量 2686 passed / 9 skipped、ESLint、Prettier、依赖审计、生产构建与完整发布检查。
- 私有部署已完成 App、Worker、PostgreSQL、内外网健康与无费用状态验收；未为本 PR 发起付费生成。