### PR TITLE
Fix image source paths in page-gallery.mdx

### DIFF
--- a/docs/content/docs/overview/page-gallery.mdx
+++ b/docs/content/docs/overview/page-gallery.mdx
@@ -12,7 +12,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
 <div className="grid gap-6 lg:grid-cols-2">
   <figure>
     <img
-      src="/screenshots/pages/01-home.webp"
+      src="/docs/public/screenshots/pages/01-home.webp"
       alt="VOZEB PRO 首页"
       loading="lazy"
       className="w-full rounded-md border"
@@ -23,7 +23,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/02-create.webp"
+      src="/docs/public/screenshots/pages/02-create.webp"
       alt="统一创作 Agent"
       loading="lazy"
       className="w-full rounded-md border"
@@ -35,7 +35,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/03-canvas-list.webp"
+      src="/docs/public/screenshots/pages/03-canvas-list.webp"
       alt="Canvas 项目列表"
       loading="lazy"
       className="w-full rounded-md border"
@@ -46,7 +46,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/03a-canvas-editor.webp"
+      src="/docs/public/screenshots/pages/03a-canvas-editor.webp"
       alt="Canvas 编辑器"
       loading="lazy"
       className="w-full rounded-md border"
@@ -58,7 +58,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/04-drama-list.webp"
+      src="/docs/public/screenshots/pages/04-drama-list.webp"
       alt="短剧项目列表"
       loading="lazy"
       className="w-full rounded-md border"
@@ -69,7 +69,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/04a-drama-editor.webp"
+      src="/docs/public/screenshots/pages/04a-drama-editor.webp"
       alt="短剧生产编辑器"
       loading="lazy"
       className="w-full rounded-md border"
@@ -81,7 +81,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/07-prompts.webp"
+      src="/docs/public/screenshots/pages/07-prompts.webp"
       alt="公共提示词库"
       loading="lazy"
       className="w-full rounded-md border"
@@ -93,7 +93,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/08-my-prompts.webp"
+      src="/docs/public/screenshots/pages/08-my-prompts.webp"
       alt="我的提示词"
       loading="lazy"
       className="w-full rounded-md border"
@@ -104,7 +104,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/09-assets.webp"
+      src="/docs/public/screenshots/pages/09-assets.webp"
       alt="我的素材"
       loading="lazy"
       className="w-full rounded-md border"
@@ -116,7 +116,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/10-help.webp"
+      src="/docs/public/screenshots/pages/10-help.webp"
       alt="工作台帮助中心"
       loading="lazy"
       className="w-full rounded-md border"
@@ -128,7 +128,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/11-profile.webp"
+      src="/docs/public/screenshots/pages/11-profile.webp"
       alt="个人中心"
       loading="lazy"
       className="w-full rounded-md border"
@@ -140,7 +140,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/12-billing.webp"
+      src="/docs/public/screenshots/pages/12-billing.webp"
       alt="充值与套餐页面"
       loading="lazy"
       className="w-full rounded-md border"
@@ -151,7 +151,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/13-announcements.webp"
+      src="/docs/public/screenshots/pages/13-announcements.webp"
       alt="公告中心"
       loading="lazy"
       className="w-full rounded-md border"
@@ -167,7 +167,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
 <div className="grid gap-6 lg:grid-cols-2">
   <figure>
     <img
-      src="/screenshots/pages/42-login.webp"
+      src="/docs/public/screenshots/pages/42-login.webp"
       alt="登录页面"
       loading="lazy"
       className="w-full rounded-md border"
@@ -179,7 +179,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/43-register.webp"
+      src="/docs/public/screenshots/pages/43-register.webp"
       alt="注册页面"
       loading="lazy"
       className="w-full rounded-md border"
@@ -190,7 +190,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/44-forgot-password.webp"
+      src="/docs/public/screenshots/pages/44-forgot-password.webp"
       alt="找回密码页面"
       loading="lazy"
       className="w-full rounded-md border"
@@ -201,7 +201,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/45-privacy.webp"
+      src="/docs/public/screenshots/pages/45-privacy.webp"
       alt="隐私政策页面"
       loading="lazy"
       className="w-full rounded-md border"
@@ -213,7 +213,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/46-terms.webp"
+      src="/docs/public/screenshots/pages/46-terms.webp"
       alt="服务条款页面"
       loading="lazy"
       className="w-full rounded-md border"
@@ -229,7 +229,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
 <div className="grid gap-6 lg:grid-cols-2">
   <figure>
     <img
-      src="/screenshots/pages/20-admin-overview.webp"
+      src="/docs/public/screenshots/pages/20-admin-overview.webp"
       alt="管理后台经营看板"
       loading="lazy"
       className="w-full rounded-md border"
@@ -240,7 +240,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/21-admin-users.webp"
+      src="/docs/public/screenshots/pages/21-admin-users.webp"
       alt="管理后台用户运营"
       loading="lazy"
       className="w-full rounded-md border"
@@ -252,7 +252,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/22-admin-logs.webp"
+      src="/docs/public/screenshots/pages/22-admin-logs.webp"
       alt="管理后台调用记录"
       loading="lazy"
       className="w-full rounded-md border"
@@ -263,7 +263,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/23-admin-generation.webp"
+      src="/docs/public/screenshots/pages/23-admin-generation.webp"
       alt="管理后台生成运营"
       loading="lazy"
       className="w-full rounded-md border"
@@ -275,7 +275,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/24-admin-products.webp"
+      src="/docs/public/screenshots/pages/24-admin-products.webp"
       alt="管理后台套餐管理"
       loading="lazy"
       className="w-full rounded-md border"
@@ -287,7 +287,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/25-admin-orders.webp"
+      src="/docs/public/screenshots/pages/25-admin-orders.webp"
       alt="管理后台订单管理"
       loading="lazy"
       className="w-full rounded-md border"
@@ -299,7 +299,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/26-admin-points.webp"
+      src="/docs/public/screenshots/pages/26-admin-points.webp"
       alt="管理后台积分规则"
       loading="lazy"
       className="w-full rounded-md border"
@@ -310,7 +310,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/27-admin-payments.webp"
+      src="/docs/public/screenshots/pages/27-admin-payments.webp"
       alt="管理后台支付渠道"
       loading="lazy"
       className="w-full rounded-md border"
@@ -322,7 +322,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/28-admin-cdk.webp"
+      src="/docs/public/screenshots/pages/28-admin-cdk.webp"
       alt="管理后台 CDK 兑换"
       loading="lazy"
       className="w-full rounded-md border"
@@ -333,7 +333,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/29-admin-wallet.webp"
+      src="/docs/public/screenshots/pages/29-admin-wallet.webp"
       alt="管理后台财务流水"
       loading="lazy"
       className="w-full rounded-md border"
@@ -344,7 +344,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/30-admin-site.webp"
+      src="/docs/public/screenshots/pages/30-admin-site.webp"
       alt="管理后台站点资料"
       loading="lazy"
       className="w-full rounded-md border"
@@ -356,7 +356,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/31-admin-settings.webp"
+      src="/docs/public/screenshots/pages/31-admin-settings.webp"
       alt="管理后台基础设置"
       loading="lazy"
       className="w-full rounded-md border"
@@ -368,7 +368,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/32-admin-deletion.webp"
+      src="/docs/public/screenshots/pages/32-admin-deletion.webp"
       alt="管理后台注销申请"
       loading="lazy"
       className="w-full rounded-md border"
@@ -380,7 +380,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/33-admin-updates.webp"
+      src="/docs/public/screenshots/pages/33-admin-updates.webp"
       alt="管理后台版本更新"
       loading="lazy"
       className="w-full rounded-md border"
@@ -392,7 +392,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/34-admin-channels.webp"
+      src="/docs/public/screenshots/pages/34-admin-channels.webp"
       alt="管理后台模型渠道"
       loading="lazy"
       className="w-full rounded-md border"
@@ -405,7 +405,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/35-admin-skills.webp"
+      src="/docs/public/screenshots/pages/35-admin-skills.webp"
       alt="管理后台 Agent Skills"
       loading="lazy"
       className="w-full rounded-md border"
@@ -417,7 +417,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/36-admin-local-media.webp"
+      src="/docs/public/screenshots/pages/36-admin-local-media.webp"
       alt="管理后台本地媒体"
       loading="lazy"
       className="w-full rounded-md border"
@@ -429,7 +429,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/37-admin-external-storage.webp"
+      src="/docs/public/screenshots/pages/37-admin-external-storage.webp"
       alt="管理后台外部存储"
       loading="lazy"
       className="w-full rounded-md border"
@@ -441,7 +441,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/38-admin-backup.webp"
+      src="/docs/public/screenshots/pages/38-admin-backup.webp"
       alt="管理后台数据备份"
       loading="lazy"
       className="w-full rounded-md border"
@@ -453,7 +453,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/39-admin-announcements.webp"
+      src="/docs/public/screenshots/pages/39-admin-announcements.webp"
       alt="管理后台公告管理"
       loading="lazy"
       className="w-full rounded-md border"
@@ -464,7 +464,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/40-admin-prompts.webp"
+      src="/docs/public/screenshots/pages/40-admin-prompts.webp"
       alt="管理后台提示词管理"
       loading="lazy"
       className="w-full rounded-md border"
@@ -475,7 +475,7 @@ description: VOZEB PRO 用户端、公开页和管理后台的主要页面截图
   </figure>
   <figure>
     <img
-      src="/screenshots/pages/41-admin-setup.webp"
+      src="/docs/public/screenshots/pages/41-admin-setup.webp"
       alt="管理后台初始化配置中心"
       loading="lazy"
       className="w-full rounded-md border"


### PR DESCRIPTION
Updated image paths in page-gallery.mdx to point to the correct public directory.

## 变更目的
修一下文档链接，图片炸了，换到/docs/public下
<!-- 说明用户问题、修复目标或关联 Issue。 -->

## 主要变更

<!-- 只列实际发生的行为和契约变化。 -->

## 验证

- [x] 相关单元/集成测试通过
- [x] `pnpm run lint` 与类型检查通过
- [x] 涉及前端时已完成桌面和移动端浏览器回归
- [x] 涉及上游协议时已记录脱敏的真实接口结果或准确缺口
- [x] 没有提交密钥、数据库、日志、构建产物或与项目无关的文件
- [x] 已按实际变化检查 todo、pending-test、CHANGELOG 和相关文档

## 风险与回滚

<!-- 写明数据、计费、支付、部署或兼容风险；没有时写“无”。 -->
